### PR TITLE
feat: Docker compose database 연동

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ jdks/
 native/
 wrapper/
 *.idea
+.tmp/

--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,9 @@ dependencies {
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	runtimeOnly 'com.h2database:h2'
 
+	// docker compose
+	testAndDevelopmentOnly("org.springframework.boot:spring-boot-docker-compose")
+
 	// 테스트에서 lombok 사용
 	testCompileOnly 'org.projectlombok:lombok'
 	testAnnotationProcessor 'org.projectlombok:lombok'

--- a/build.gradle
+++ b/build.gradle
@@ -24,12 +24,13 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	runtimeOnly 'com.h2database:h2'
-
+	runtimeOnly 'com.mysql:mysql-connector-j'
 	// docker compose
 	testAndDevelopmentOnly("org.springframework.boot:spring-boot-docker-compose")
 

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -1,0 +1,18 @@
+version: "3.8" # 파일 규격 버전
+services: # 이 항목 밑에 실행하려는 컨테이너 들을 정의 ( 컴포즈에서 컨테이너 : 서비스 )
+  db: # 서비스 명
+    image: mysql:8.0 # 사용할 이미지
+    restart: always
+    container_name: db # 컨테이너 이름 설정
+    ports:
+      - "3306:3306" # 접근 포트 설정 (컨테이너 외부:컨테이너 내부)  <- 컨테이너 내부는 무조건 3306
+    environment: # -e 옵션
+      - MYSQL_ROOT_USER=root
+      - MYSQL_ROOT_PASSWORD=root
+      - MYSQL_USER=user
+      - MYSQL_PASSWORD=local
+      - MYSQL_DATABASE=local
+    command: # 명령어 실행
+      - --character-set-server=utf8mb4
+      - --collation-server=utf8mb4_unicode_ci
+      - --lower_case_table_names=1

--- a/init.sh
+++ b/init.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# mac x86에 대해서만 작성.
+
+######################
+# DO NOT ERASE !!
+BACKUP_IFS="$IFS" # 기존 IFS 저장 (시스템)
+######################
+IFS="" # IFS 초기화 -> function 호출 시 function 내 줄바꿈이 무시되는 것을 막기 위해 초기화
+
+check_docker(){
+  echo -e "\033[34m"Docker desktop 설치 여부 확인..."\033[0m\n"
+  ls -alt /Applications/Dockers.app/ 2> /dev/null || isDockerInstalled=$?
+
+  if [ "${isDockerInstalled}" = 1 ]; then
+    echo -e "\033[31m"
+    echo "Docker is not installed"
+    echo -e "\033[0m"
+    echo false
+  else
+    echo true
+  fi
+}
+
+isDockerInstalled=$(check_docker)
+
+######################
+# DO NOT ERASE !!
+IFS=$BACKUP_IFS # IFS 원복
+######################

--- a/init.sh
+++ b/init.sh
@@ -8,20 +8,45 @@ BACKUP_IFS="$IFS" # 기존 IFS 저장 (시스템)
 IFS="" # IFS 초기화 -> function 호출 시 function 내 줄바꿈이 무시되는 것을 막기 위해 초기화
 
 check_docker(){
-  echo -e "\033[34m"Docker desktop 설치 여부 확인..."\033[0m\n"
-  ls -alt /Applications/Dockers.app/ 2> /dev/null || isDockerInstalled=$?
-
+  echo -e "\033[33m"Checking docker by dir..."\033[0m\n"
+  ls -alt /Applications/Docker.app/ 2> /dev/null || isDockerInstalled=$?
+  echo ""
   if [ "${isDockerInstalled}" = 1 ]; then
-    echo -e "\033[31m"
-    echo "Docker is not installed"
-    echo -e "\033[0m"
-    echo false
+    echo -e "\033[31mDocker is not installed \033[0m"
+    return 0
   else
-    echo true
+    echo -e "\033[32mDocker is installed !!\033[0m"
+    return 1
   fi
 }
 
-isDockerInstalled=$(check_docker)
+install_docker(){
+  while true; do
+
+  read -p "> Will install docker desktop? (Y/N): " confirm;
+
+  case $confirm in
+  	[yY] ) echo "Installing docker with brew...";
+  	  brew install docker --cask
+  		break;;
+  	[nN] ) echo exiting...;
+  		exit;;
+  	* ) echo invalid response;;
+  esac
+  done
+  echo ""
+}
+
+# Docker Desktop 확인 및 설치
+echo -e "\033[34m"Docker desktop 설치 여부 확인"\033[0m"
+check_docker
+if [[ $? -eq 1 ]]; then
+  echo "Mac OS의 경우 Docker desktop 대신 OrbStack 사용이 좋을 수 있습니다."
+  echo "> https://orbstack.dev"
+else
+  echo -e "\n\033[34m"Docker desktop 설치"\033[0m"
+  install_docker
+fi
 
 ######################
 # DO NOT ERASE !!

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -6,6 +6,30 @@ spring:
   config:
     activate:
       on-profile: local
+  docker:
+    compose:
+      enabled: true
+      lifecycle-management: start_and_stop
+      start:
+        command: up
+      stop:
+        command: down
+        timeout: 1m
+      file: ./docker-compose.local.yml
+      skip:
+        in-tests: false
+  jpa:
+    hibernate:
+      ddl-auto: create  # option type: create, create-drop, update, validate, none
+    hikari:
+      connection-timeout: 3000
+      validation-timeout: 3000
+      minimum-idle: 5
+      max-lifetime: 240000
+      maximum-pool-size: 20**
+  logging:
+    level:
+      com.zaxxer.hikari: DEBUG
 ---
 spring:
   config:
@@ -16,3 +40,6 @@ spring:
   config:
     activate:
       on-profile: prod
+  docker:
+    compose:
+        enabled: false

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -40,7 +40,7 @@ spring:
       enabled: false
   jpa:
     hibernate:
-      ddl-auto: create  # option type: create, create-drop, update, validate, none
+      ddl-auto: validate # update or validate
     hikari:
       connection-timeout: 3000
       validation-timeout: 3000
@@ -60,7 +60,7 @@ spring:
         enabled: false
   jpa:
     hibernate:
-      ddl-auto: create  # option type: create, create-drop, update, validate, none
+      ddl-auto: none # validate 또는 none
     hikari:
       connection-timeout: 3000
       validation-timeout: 3000

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,7 +5,7 @@ spring:
 spring:
   config:
     activate:
-      on-profile: local
+      on-profile: local_docker
   docker:
     compose:
       enabled: true

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -35,6 +35,21 @@ spring:
   config:
     activate:
       on-profile: dev
+  docker:
+    compose:
+      enabled: false
+  jpa:
+    hibernate:
+      ddl-auto: create  # option type: create, create-drop, update, validate, none
+    hikari:
+      connection-timeout: 3000
+      validation-timeout: 3000
+      minimum-idle: 5
+      max-lifetime: 240000
+      maximum-pool-size: 20**
+    logging:
+      level:
+        com.zaxxer.hikari: DEBUG
 ---
 spring:
   config:
@@ -43,3 +58,15 @@ spring:
   docker:
     compose:
         enabled: false
+  jpa:
+    hibernate:
+      ddl-auto: create  # option type: create, create-drop, update, validate, none
+    hikari:
+      connection-timeout: 3000
+      validation-timeout: 3000
+      minimum-idle: 5
+      max-lifetime: 240000
+      maximum-pool-size: 20**
+    logging:
+      level:
+        com.zaxxer.hikari: INFO


### PR DESCRIPTION
## New features
### `./init.sh`을 통해 docker desktop 자동 설치
-  ✅ Mac X86
- ❔ Mac ARM
- ❔ Debain
- ❔ Redhat
- ❌  Window
### Use spring docker compose support
- spring docker compose support를 사용해 jpa와 연결
- 해당 라이브러리 사용 시 `dataSource.url` 등을 `application.yml`에 작성하지 않아도 자동으로 configure 해줌

### Mysql 8.0, hikari 연결

## Not working
### ❌ Prod, dev는 작동하지 않음
- datasource option에 필요한 항목들을 아직 지정하지 않음

### ❌ 유효하지 않은 데이터베이스 option들
- `docker-compose.local.yml`의 connection option 미설정
- `application.yml`의 hikari option에 임의의 값 설정
  ``` YML
    hikari:
     connection-timeout: 3000
      validation-timeout: 3000
      minimum-idle: 5
      max-lifetime: 240000
      maximum-pool-size: 20**