### PR TITLE
feat: AOP를 통한 controller - service - repository 로깅

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,4 @@ native/
 wrapper/
 *.idea
 .tmp/
+logs/

--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,7 @@ dependencies {
 
 	// Logback을 log4j2로 대체
 	implementation("org.springframework.boot:spring-boot-starter-log4j2")
+	implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml'
 	modules {
 		module("org.springframework.boot:spring-boot-starter-logging") {
 			replacedBy("org.springframework.boot:spring-boot-starter-log4j2")

--- a/build.gradle
+++ b/build.gradle
@@ -39,7 +39,7 @@ dependencies {
 	testCompileOnly 'org.projectlombok:lombok'
 	testAnnotationProcessor 'org.projectlombok:lombok'
 
-	//
+	// Logback을 log4j2로 대체
 	implementation("org.springframework.boot:spring-boot-starter-log4j2")
 	modules {
 		module("org.springframework.boot:spring-boot-starter-logging") {

--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,10 @@ dependencies {
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	runtimeOnly 'com.h2database:h2'
 	runtimeOnly 'com.mysql:mysql-connector-j'
+
+	// aop
+	implementation 'org.springframework.boot:spring-boot-starter-aop'
+
 	// docker compose
 	testAndDevelopmentOnly("org.springframework.boot:spring-boot-docker-compose")
 

--- a/src/main/java/com/example/base/domain/user/controller/UserController.java
+++ b/src/main/java/com/example/base/domain/user/controller/UserController.java
@@ -17,7 +17,7 @@ public class UserController {
     }
 
     @GetMapping("/user")
-    public String test(){
+    public String createUser(){
         return this.userService.createUser(new User()).toString();
     }
 }

--- a/src/main/java/com/example/base/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/example/base/domain/user/repository/UserRepository.java
@@ -17,7 +17,6 @@ public class UserRepository  {
     EntityManager em;
 
     public void save(User user){
-        Logger logger = LoggerFactory.getLogger(UserRepository.class);
         em.persist(user);
     }
 

--- a/src/main/java/com/example/base/domain/user/service/UserService.java
+++ b/src/main/java/com/example/base/domain/user/service/UserService.java
@@ -14,7 +14,7 @@ import org.springframework.stereotype.Service;
 public class UserService {
 
     private final UserRepository userRepository;
-    private final Logger logger = LoggerFactory.getLogger(UserService.class);
+
     @Autowired
     public UserService(UserRepository userRepository){
         this.userRepository = userRepository;
@@ -23,8 +23,6 @@ public class UserService {
     public String createUser(User user){
         this.userRepository.save(user);
         String id = TypeConvertor.byteArrayToHexString(user.getId());
-
-        this.logger.warn(id);
 
         return id;
     }

--- a/src/main/java/com/example/base/domain/user/service/UserService.java
+++ b/src/main/java/com/example/base/domain/user/service/UserService.java
@@ -4,8 +4,6 @@ import com.example.base.domain.user.domain.User;
 import com.example.base.domain.user.repository.UserRepository;
 import com.example.base.global.util.convertor.TypeConvertor;
 import jakarta.transaction.Transactional;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -23,8 +21,6 @@ public class UserService {
     public String createUser(User user){
         this.userRepository.save(user);
         String id = TypeConvertor.byteArrayToHexString(user.getId());
-
         return id;
     }
-
 }

--- a/src/main/java/com/example/base/global/aop/PointCut.java
+++ b/src/main/java/com/example/base/global/aop/PointCut.java
@@ -1,0 +1,28 @@
+package com.example.base.global.aop;
+
+import org.aspectj.lang.annotation.Pointcut;
+
+public class PointCut {
+
+    @Pointcut("execution(* com.example.base..*.*(..))")
+    public void basePackage() {}
+
+    @Pointcut("execution(* *..*Controller.*(..))")
+    public void allController() {}
+
+    @Pointcut("execution(* *..*Service.*(..))")
+    public void allService() {}
+
+    @Pointcut("execution(* *..*Repository.*(..))")
+    public void allRepository(){}
+
+
+    @Pointcut("basePackage() && allController()")
+    public void allControllerUnderBasePackage() {}
+
+    @Pointcut("basePackage() && allService()")
+    public void allServiceUnderBasePackage() {}
+
+    @Pointcut("basePackage() && allRepository()")
+    public void allRepositoryUnderBasePackage(){}
+}

--- a/src/main/java/com/example/base/global/aop/logger/LayeredArchitectureLogAspect.java
+++ b/src/main/java/com/example/base/global/aop/logger/LayeredArchitectureLogAspect.java
@@ -60,7 +60,7 @@ public class LayeredArchitectureLogAspect {
                 return result;
             } finally {
                 // After
-                log.error("class :{}", joinPoint.getSignature().toShortString());
+                log.trace("Clear ThreadContext");
                 ThreadContext.clearMap();
                 return result;
             }

--- a/src/main/java/com/example/base/global/aop/logger/LayeredArchitectureLogAspect.java
+++ b/src/main/java/com/example/base/global/aop/logger/LayeredArchitectureLogAspect.java
@@ -1,0 +1,110 @@
+package com.example.base.global.aop.logger;
+
+import lombok.extern.slf4j.Slf4j;
+import org.apache.logging.log4j.ThreadContext;
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.*;
+import org.hibernate.mapping.Join;
+import org.springframework.stereotype.Component;
+
+import java.util.UUID;
+
+@Slf4j
+public class LayeredArchitectureLogAspect {
+
+    private static String DEFAULT_INPUT_MESSAGE_FORMAT = "[{}] >> Input :: {} :: {}";
+    private static String DEFAULT_OUTPUT_MESSAGE_FORMAT = "[{}] << Output :: {} :: {}";
+    private static String DEFAULT_ERROR_MESSAGE_FORMAT = "[{}] {} :: {}";
+
+    public static void defaultTraceInputLog(JoinPoint joinPoint){
+        log.trace(DEFAULT_INPUT_MESSAGE_FORMAT, joinPoint.getSignature().toShortString(),
+                joinPoint.getArgs(),
+                joinPoint.getTarget().getClass());
+    }
+
+    public static void defaultTraceOutputLog(JoinPoint joinPoint, Object result){
+        log.trace(DEFAULT_OUTPUT_MESSAGE_FORMAT, joinPoint.getSignature().toShortString(),
+                result,
+                joinPoint.getTarget().getClass());
+    }
+    public static void errorLog(JoinPoint joinPoint, Exception e){
+        log.error(DEFAULT_ERROR_MESSAGE_FORMAT, joinPoint.getSignature().toShortString(),
+                e.getMessage(),
+                joinPoint.getTarget().getClass() ,e);
+    }
+
+    @Aspect
+    @Component
+    public static class BaseLogAspect{
+        @Around("com.example.base.global.aop.PointCut.allControllerUnderBasePackage()")
+        public static Object logControllerUnderBasePackage(ProceedingJoinPoint joinPoint) throws Throwable{
+            if(ThreadContext.isEmpty()) {
+                ThreadContext.put("id", UUID.randomUUID().toString().substring(0,8));
+            }
+            Object result = null;
+            try {
+                // Before
+                defaultTraceInputLog(joinPoint);
+
+                // Proceed
+                result = joinPoint.proceed();
+
+                // After return
+                defaultTraceOutputLog(joinPoint, result);
+
+                return result;
+            } catch (Exception e) {
+                // AfterThrowing
+                errorLog(joinPoint, e);
+                return result;
+            } finally {
+                // After
+                log.error("class :{}", joinPoint.getSignature().toShortString());
+                ThreadContext.clearMap();
+                return result;
+            }
+        }
+    }
+    @Aspect
+    @Component
+    public static class ServiceLogAspect{
+        @Around("com.example.base.global.aop.PointCut.allServiceUnderBasePackage()")
+        public static Object logControllerUnderBasePackage(ProceedingJoinPoint joinPoint) throws Throwable{
+            Object result = null;
+            try {
+                defaultTraceInputLog(joinPoint);
+
+                result = joinPoint.proceed();
+
+                defaultTraceOutputLog(joinPoint, result);
+                return result;
+            } catch (Exception e){
+                errorLog(joinPoint, e);
+            } finally {
+                return result;
+            }
+        }
+    }
+
+    @Aspect
+    @Component
+    public static class RepositoryLogAspect {
+        @Around("com.example.base.global.aop.PointCut.allRepositoryUnderBasePackage()")
+        public static Object logControllerUnderBasePackage(ProceedingJoinPoint joinPoint) throws Throwable {
+            Object result = null;
+            try {
+                defaultTraceInputLog(joinPoint);
+
+                result = joinPoint.proceed();
+
+                defaultTraceOutputLog(joinPoint, result);
+
+            } catch (Exception e) {
+                errorLog(joinPoint, e);
+            } finally {
+                return result;
+            }
+        }
+    }
+}

--- a/src/main/java/com/example/base/global/util/generator/UUID.java
+++ b/src/main/java/com/example/base/global/util/generator/UUID.java
@@ -36,8 +36,6 @@ public class UUID {
         ByteBuffer bb = ByteBuffer.wrap(new byte[16]);
         bb.putLong(Long.parseUnsignedLong(uuidWithoutHyphen.substring(0, 16), 16));
         bb.putLong(Long.parseUnsignedLong(uuidWithoutHyphen.substring(16), 16));
-        System.out.println(uuidWithoutHyphen);
-        System.out.println(bb.array());
         return bb.array();
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -19,7 +19,7 @@ spring:
     properties:
       hibernate:
         format_sql: true # 여러줄로 만들어 이쁘게 출력
-        show_sql: true
+#        show_sql: true # log4j2에서 debug 레벨로 설정했기 때문에 비활성화
         use_sql_comments: true # format_sql을 true로 둘 경우 sql 주변에 /**/을 추가
         highlight_sql: true
   output:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -19,7 +19,7 @@ spring:
     properties:
       hibernate:
         format_sql: true # 여러줄로 만들어 이쁘게 출력
-#        show_sql: true # log4j2에서 debug 레벨로 설정했기 때문에 비활성화
+#        show_sql: true # System.out 으로 출력
         use_sql_comments: true # format_sql을 true로 둘 경우 sql 주변에 /**/을 추가
         highlight_sql: true
   output:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -18,13 +18,10 @@ spring:
       ddl-auto: create # option type: create, create-drop, update, validate, none
     properties:
       hibernate:
-        format_sql: true # 실행 query
+        format_sql: true # 여러줄로 만들어 이쁘게 출력
         show_sql: true
-        use_sql_comments: true
-  logging:
-    level:
-      com.zaxxer.hikari: DEBUG
-      org.hibernate.SQL: DEBUG
+        use_sql_comments: true # format_sql을 true로 둘 경우 sql 주변에 /**/을 추가
+        highlight_sql: true
   output:
     ansi:
       enabled: ALWAYS
@@ -33,6 +30,8 @@ spring:
   config:
     activate:
       on-profile: local
+  logging:
+    config: classpath:log4j2.yml
 ---
 spring:
   config:

--- a/src/main/resources/log4j2.yml
+++ b/src/main/resources/log4j2.yml
@@ -12,7 +12,7 @@ Configuration:
       - name: "developer-layout-pattern"
         value: "%highlight{[%-5level]} %d{MM-dd HH:mm:ss} [%t] %n [%X{id}] %msg%n%n"
       - name: "layout-pattern"
-        value: "%highlight{[%-5level]} %d{yyyy-MM-dd HH:mm:ss.SSS} %u{RANDOM} [%t] [%M() in %C{1.}] - %msg%n"
+        value: "%highlight{[%-5level]} %d{yyyy-MM-dd HH:mm:ss.SSS} %u{RANDOM} [%t] [%X{id}] - %msg%n"
       - name: "info-log"
         value: ${log-path}/base/info.log
       - name: "error-log"

--- a/src/main/resources/log4j2.yml
+++ b/src/main/resources/log4j2.yml
@@ -1,0 +1,94 @@
+Configuration:
+  name: default
+
+  properties:
+    property:
+      - name: "log-path"
+        value: "./logs"
+      - name: "charset-UTF-8"
+        value: "UTF-8"
+      - name: "layout-pattern"
+        value: "%highlight{[%-5level]} %d{yyyy-MM-dd HH:mm:ss.SSS} [%t][%F] %c{1} - %msg%n"
+      - name: "info-log"
+        value: ${log-path}/base/info.log
+      - name: "error-log"
+        value: ${log-path}/base/error.log
+      - name: "auth-log"
+        value: ${log-path}/base/auth.log
+      - name: "json-log"
+        value: ${log-path}/base/json-info.log
+  # [Appenders] 로그 기록방식 정의
+  Appenders:
+    # [Appenders - Console] 콘솔에 로그를 출력하는 방식 정의
+    Console:
+      name: console-appender
+      target: SYSTEM_OUT
+      PatternLayout:
+        pattern: ${layout-pattern}
+    # [Appenders - RollingFile] 로그를 파일들을 압축파일로 출력하는 방식 정의
+    RollingFile:
+      name: rolling-file-appender
+      fileName: ${log-path}/rolling-file.log
+      filePattern: "logs/archive/rolling-file.log.%d{yyyy-MM-dd-hh-mm}_%i.gz"
+      PatternLayout:
+        charset: ${charset-UTF-8}
+        pattern: ${layout-pattern}
+      Policies:
+        SizeBasedTriggeringPolicy:
+          size: "200KB"
+        TimeBasedTriggeringPolicy:
+          interval: "1"
+      DefaultRollOverStrategy:
+        max: "30"
+        fileIndex: "max"
+    # [Appenders - File] 로그를 파일로 기록하는 방식 정의
+    File:
+      - name: file-info-appender
+        fileName: ${info-log}
+        PatternLayout:
+          pattern: "%d %p %C{1.} [%t] %m%n"
+      - name: file-error-appender
+        fileName: ${error-log}
+        PatternLayout:
+          pattern: "%d %p %C{1.} [%t] %m%n"
+      - name: file-auth-appender
+        fileName: ${auth-log}
+        PatternLayout:
+          pattern: "%d %p %C{1.} [%t] %m%n"
+      - name: file-json-info-appender
+        fileName: ${json-log}
+        PatternLayout:
+          pattern: "%d %p %C{1.} [%t] %m%n"
+  # [Loggers] 로그 출력 범위를 정의
+  Loggers:
+    # [Loggers - Root] 모든 로그를 기록하는 최상위 로그를 정의
+    Root:
+      level: OFF
+      AppenderRef:
+        - ref: console-appender
+        - ref: rolling-file-appender
+    # [Loggers - Loggers] 특정 패키지나 클래스에 대한 로그를 정의
+    Logger:
+      # 1. Spring Framework 로그 레벨 'INFO' 정의
+      - name: org.springframework
+        additivity: "false" # 중복로깅여부, true or false
+        level: INFO
+        AppenderRef:
+          - ref: console-appender
+          - ref: file-info-appender
+          - ref: file-error-appender
+      # 2. Spring Framework 로그 레벨 'DEBUG' 정의
+      - name: com.example.base
+        additivity: "false"
+        level: DEBUG
+        AppenderRef:
+          - ref: console-appender
+          - ref: file-info-appender
+          - ref: file-error-appender
+      # 3 JPA
+      - name: com.zaxxer.hikari
+        level: DEBUG
+      - name: org.hibernate.SQL
+        level: DEBUG
+      - name : org.hibernate.orm.jdbc.bind
+        level: trace

--- a/src/main/resources/log4j2.yml
+++ b/src/main/resources/log4j2.yml
@@ -10,7 +10,7 @@ Configuration:
 #      - name: "developer-layout-pattern"
 #        value: "%highlight{[%-5level]} %d{MM-dd HH:mm:ss} [%t(%T)] [%M() in %highlight{%C{1.}}] %n [MSG] %msg%n%n"
       - name: "developer-layout-pattern"
-        value: "%highlight{[%-5level]} %d{MM-dd HH:mm:ss} %u{RANDOM} %n %msg%n%n"
+        value: "%highlight{[%-5level]} %d{MM-dd HH:mm:ss} [%t] %n [%X{id}] %msg%n%n"
       - name: "layout-pattern"
         value: "%highlight{[%-5level]} %d{yyyy-MM-dd HH:mm:ss.SSS} %u{RANDOM} [%t] [%M() in %C{1.}] - %msg%n"
       - name: "info-log"

--- a/src/main/resources/log4j2.yml
+++ b/src/main/resources/log4j2.yml
@@ -12,7 +12,7 @@ Configuration:
       - name: "developer-layout-pattern"
         value: "%highlight{[%-5level]} %d{MM-dd HH:mm:ss} [%t] %n [%X{id}] %msg%n%n"
       - name: "layout-pattern"
-        value: "%highlight{[%-5level]} %d{yyyy-MM-dd HH:mm:ss.SSS} %u{RANDOM} [%t] [%X{id}] - %msg%n"
+        value: "%highlight{[%-5level]} %d{yyyy-MM-dd HH:mm:ss.SSS} [%t] [%X{id}] - %msg%n"
       - name: "info-log"
         value: ${log-path}/base/info.log
       - name: "error-log"

--- a/src/main/resources/log4j2.yml
+++ b/src/main/resources/log4j2.yml
@@ -7,8 +7,10 @@ Configuration:
         value: "./logs"
       - name: "charset-UTF-8"
         value: "UTF-8"
+#      - name: "developer-layout-pattern"
+#        value: "%highlight{[%-5level]} %d{MM-dd HH:mm:ss} [%t(%T)] [%M() in %highlight{%C{1.}}] %n [MSG] %msg%n%n"
       - name: "developer-layout-pattern"
-        value: "%highlight{[%-5level]} %d{MM-dd HH:mm:ss} [%t(%T)] [%M() in %highlight{%C{1.}}] %n [MSG] %msg%n%n"
+        value: "%highlight{[%-5level]} %d{MM-dd HH:mm:ss} %u{RANDOM} %n %msg%n%n"
       - name: "layout-pattern"
         value: "%highlight{[%-5level]} %d{yyyy-MM-dd HH:mm:ss.SSS} %u{RANDOM} [%t] [%M() in %C{1.}] - %msg%n"
       - name: "info-log"
@@ -82,14 +84,14 @@ Configuration:
       # 2. Spring Framework 로그 레벨 'DEBUG' 정의
       - name: com.example.base
         additivity: "false"
-        level: DEBUG
+        level: TRACE
         AppenderRef:
           - ref: console-appender
           - ref: file-info-appender
           - ref: file-error-appender
       # 3 JPA
       - name: com.zaxxer.hikari
-        level: DEBUG
+        level: OFF
       - name: org.hibernate.SQL
         level: DEBUG
       - name : org.hibernate.orm.jdbc.bind

--- a/src/main/resources/log4j2.yml
+++ b/src/main/resources/log4j2.yml
@@ -7,8 +7,10 @@ Configuration:
         value: "./logs"
       - name: "charset-UTF-8"
         value: "UTF-8"
+      - name: "developer-layout-pattern"
+        value: "%highlight{[%-5level]} %d{MM-dd HH:mm:ss} [%t(%T)] [%M() in %highlight{%C{1.}}] %n [MSG] %msg%n%n"
       - name: "layout-pattern"
-        value: "%highlight{[%-5level]} %d{yyyy-MM-dd HH:mm:ss.SSS} [%t][%F] %c{1} - %msg%n"
+        value: "%highlight{[%-5level]} %d{yyyy-MM-dd HH:mm:ss.SSS} %u{RANDOM} [%t] [%M() in %C{1.}] - %msg%n"
       - name: "info-log"
         value: ${log-path}/base/info.log
       - name: "error-log"
@@ -24,7 +26,7 @@ Configuration:
       name: console-appender
       target: SYSTEM_OUT
       PatternLayout:
-        pattern: ${layout-pattern}
+        pattern: ${developer-layout-pattern}
     # [Appenders - RollingFile] 로그를 파일들을 압축파일로 출력하는 방식 정의
     RollingFile:
       name: rolling-file-appender


### PR DESCRIPTION
## New features
### AOP 로깅
- 타겟
  - `com.example.base` 패키지 내 `Controller`, `Service`, `Repository`
- 로그
  - Input, output 로깅
    - 레벨 :: `trace`
  - 에러 로깅
    - 레벨 :: `error`
## Dependency
- `com.fasterxml.jackson.dataformat:jackson-dataformat-yaml`
  - yml을 input으로 읽어드리는 라이브러리
  - 해당 라이브러리를 통해 log4j2.yml을 읽어들임
- `implementation 'org.springframework.boot:spring-boot-starter-aop`
  - aop를 위한 라이브러리
## ETC
### Screen Shot
#### `${developer-layout-pattern}`
![스크린샷 2024-05-29 오후 5 34 29](https://github.com/can019/spring-base/assets/26926966/9b3c96c1-96be-4a96-94bd-6f0741d0d2a6)

#### `${layout-pattern}`
![스크린샷 2024-05-29 오후 5 36 17](https://github.com/can019/spring-base/assets/26926966/cde67c1f-cec0-4bfc-b826-502110c9ae72)
