### PR TITLE
feat: Exception logging

### DIFF
--- a/src/main/java/com/example/base/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/example/base/domain/user/repository/UserRepository.java
@@ -2,6 +2,7 @@ package com.example.base.domain.user.repository;
 
 
 import com.example.base.domain.user.domain.User;
+import com.example.base.global.exception.ApplicationException;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
 import org.springframework.stereotype.Repository;

--- a/src/main/java/com/example/base/global/aop/logger/LayeredArchitectureLogAspect.java
+++ b/src/main/java/com/example/base/global/aop/logger/LayeredArchitectureLogAspect.java
@@ -10,7 +10,7 @@ public class LayeredArchitectureLogAspect {
 
     private static String DEFAULT_INPUT_MESSAGE_FORMAT = "[{}] >> Input :: {} :: {}";
     private static String DEFAULT_OUTPUT_MESSAGE_FORMAT = "[{}] << Output :: {} :: {}";
-    private static String DEFAULT_ERROR_MESSAGE_FORMAT = "[{}] {} :: {}";
+    private static String DEFAULT_ERROR_MESSAGE_FORMAT = "[{}] {} :: {} {}";
 
     public static void defaultTraceInputLog(JoinPoint joinPoint){
         log.trace(DEFAULT_INPUT_MESSAGE_FORMAT, joinPoint.getSignature().toShortString(),
@@ -24,9 +24,8 @@ public class LayeredArchitectureLogAspect {
                 joinPoint.getTarget().getClass());
     }
     public static void errorLog(JoinPoint joinPoint, Throwable e){
-        log.error(DEFAULT_ERROR_MESSAGE_FORMAT, joinPoint.getSignature().toShortString(),
-                e.getMessage(),
-                joinPoint.getTarget().getClass() ,e);
+        log.error(DEFAULT_ERROR_MESSAGE_FORMAT, joinPoint.getSignature().toShortString() ,
+                e.getMessage(), e.getStackTrace()[0], e.getClass().getName());
     }
 
     @Aspect
@@ -42,7 +41,7 @@ public class LayeredArchitectureLogAspect {
             defaultTraceOutputLog(joinPoint, result);
         }
 
-        @AfterThrowing(pointcut = "com.example.base.global.aop.PointCut.allControllerServiceRepositoryUnderBasePackage()", throwing="e")
+        @AfterThrowing(pointcut = "com.example.base.global.aop.PointCut.allControllerUnderBasePackage()", throwing="e")
         public void doAfterThrowing(JoinPoint joinPoint, Throwable e){
             errorLog(joinPoint, e);
         }

--- a/src/main/java/com/example/base/global/exception/ApplicationException.java
+++ b/src/main/java/com/example/base/global/exception/ApplicationException.java
@@ -22,6 +22,7 @@ public class ApplicationException extends RuntimeException implements ErrorRespo
     }
 
     public ApplicationException(String message, Throwable cause){
+        super(message, cause);
         this.httpStatus = HttpStatus.INTERNAL_SERVER_ERROR;
         this.body = ProblemDetail.forStatusAndDetail(getStatusCode(), message);
         this.body.setTitle(DEFAULT_DETAIL);

--- a/src/main/java/com/example/base/global/exception/UnknownException.java
+++ b/src/main/java/com/example/base/global/exception/UnknownException.java
@@ -20,7 +20,7 @@ public class UnknownException extends RuntimeException implements ErrorResponse 
     }
 
     public UnknownException(String message, Throwable cause){
-        super(cause);
+        super(message, cause);
         this.httpStatus = HttpStatus.INTERNAL_SERVER_ERROR;
         this.body = ProblemDetail.forStatusAndDetail(getStatusCode(), message);
         this.body.setTitle(DEFAULT_DETAIL);

--- a/src/main/java/com/example/base/global/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/base/global/handler/GlobalExceptionHandler.java
@@ -5,6 +5,7 @@ import com.example.base.global.exception.UnknownException;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.logging.log4j.ThreadContext;
 import org.springframework.context.i18n.LocaleContextHolder;
 import org.springframework.http.*;
 import org.springframework.lang.Nullable;
@@ -51,7 +52,9 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
                 errorResponse.getBody().setProperty("code", ExceptionCode.APPLICATION_ERROR_CODE.getExceptionCode());
             } else{
                 errorResponse.getBody().setProperty("code", ExceptionCode.FATAL_ERROR_CODE.getExceptionCode());
+
             }
+            errorResponse.getBody().setProperty("uuid", ThreadContext.get("id"));
             body = errorResponse.updateAndGetBody(getMessageSource(), LocaleContextHolder.getLocale());
         }
 

--- a/src/main/java/com/example/base/global/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/base/global/handler/GlobalExceptionHandler.java
@@ -51,8 +51,8 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
             } else if(ex instanceof  ApplicationException){
                 errorResponse.getBody().setProperty("code", ExceptionCode.APPLICATION_ERROR_CODE.getExceptionCode());
             } else{
+                log.error("[FATAL] {} {}", ex.getMessage(), ex.getStackTrace()[0]);
                 errorResponse.getBody().setProperty("code", ExceptionCode.FATAL_ERROR_CODE.getExceptionCode());
-
             }
             errorResponse.getBody().setProperty("uuid", ThreadContext.get("id"));
             body = errorResponse.updateAndGetBody(getMessageSource(), LocaleContextHolder.getLocale());


### PR DESCRIPTION
## ✨ New features
### Fatal exception 발생 시 로깅
- `GlobalExceptionHandler`에서 fatal exception response body 생성 전 로깅
  - FATAL exception의 경우 AOP에서 로깅이 안될 가능성이 있음
  - AOP에서 로깅이 되는 경우 로직을 잘못 짠 경우 
## 🐛 Fix
### `ApplicationExeption`, `UnknownException`의 e.getMessage()가 null로 출력되는 문제
- `super()`를 호출하지 않아 발생했던 문제
## ✏️ Changed
### AOP 로깅
- 에러 로깅 시 controller에서만 로그를 찍도록 변경
- 에러 로그 양식 변경
```java
private static String DEFAULT_ERROR_MESSAGE_FORMAT = "[{}] {} :: {} {}";

log.error(DEFAULT_ERROR_MESSAGE_FORMAT, joinPoint.getSignature().toShortString() ,
                e.getMessage(), e.getStackTrace()[0], e.getClass().getName());
``` 
## 📝 Docs
## ETC
### 📸  Screen Shot
####  로깅
- ApplicationException
![스크린샷 2024-06-11 오전 11 22 24](https://github.com/can019/spring-base/assets/26926966/da66500e-3546-4ab4-b065-707b92073d25)
- Fata exception (RuntimeException)
![스크린샷 2024-06-11 오전 11 26 48](https://github.com/can019/spring-base/assets/26926966/e4393a53-fcbc-432c-8933-f6a17b02daa7)
#### Except


ion response body

- ApplicationException
<img width="293" alt="스크린샷 2024-06-11 오전 11 23 50" src="https://github.com/can019/spring-base/assets/26926966/c71eede5-7701-4de1-a9f0-110ea07ae0b8">

- Fata exception (RuntimeException)
<img width="328" alt="스크린샷 2024-06-11 오전 11 29 22" src="https://github.com/can019/spring-base/assets/26926966/407da511-05cb-4981-97dc-db01c76b2130">


