### PR TITLE
feat: Exception handling resolve issue #14

### DIFF
--- a/src/main/java/com/example/base/BaseApplication.java
+++ b/src/main/java/com/example/base/BaseApplication.java
@@ -2,9 +2,12 @@ package com.example.base;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 import org.springframework.boot.web.servlet.ServletComponentScan;
 
 @SpringBootApplication
+@ConfigurationPropertiesScan("com.example.base.config")
+@ServletComponentScan
 public class BaseApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/example/base/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/example/base/domain/user/repository/UserRepository.java
@@ -2,6 +2,7 @@ package com.example.base.domain.user.repository;
 
 
 import com.example.base.domain.user.domain.User;
+import com.example.base.global.exception.ApplicationException;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
 import org.springframework.stereotype.Repository;

--- a/src/main/java/com/example/base/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/example/base/domain/user/repository/UserRepository.java
@@ -4,11 +4,7 @@ package com.example.base.domain.user.repository;
 import com.example.base.domain.user.domain.User;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Repository;
-
-import java.util.List;
 
 @Repository
 public class UserRepository  {

--- a/src/main/java/com/example/base/global/aop/PointCut.java
+++ b/src/main/java/com/example/base/global/aop/PointCut.java
@@ -26,6 +26,6 @@ public class PointCut {
     @Pointcut("basePackage() && allRepository()")
     public void allRepositoryUnderBasePackage(){}
 
-    @Pointcut("basePackage() && allRepository() && allService() && allController()")
+    @Pointcut("basePackage() && (allRepository() || allService() || allController()) ")
     public void allControllerServiceRepositoryUnderBasePackage(){}
 }

--- a/src/main/java/com/example/base/global/aop/logger/LayeredArchitectureLogAspect.java
+++ b/src/main/java/com/example/base/global/aop/logger/LayeredArchitectureLogAspect.java
@@ -10,7 +10,7 @@ public class LayeredArchitectureLogAspect {
 
     private static String DEFAULT_INPUT_MESSAGE_FORMAT = "[{}] >> Input :: {} :: {}";
     private static String DEFAULT_OUTPUT_MESSAGE_FORMAT = "[{}] << Output :: {} :: {}";
-    private static String DEFAULT_ERROR_MESSAGE_FORMAT = "[{}] {} :: {}";
+    private static String DEFAULT_ERROR_MESSAGE_FORMAT = "[{}] {} :: {} {}";
 
     public static void defaultTraceInputLog(JoinPoint joinPoint){
         log.trace(DEFAULT_INPUT_MESSAGE_FORMAT, joinPoint.getSignature().toShortString(),
@@ -24,9 +24,8 @@ public class LayeredArchitectureLogAspect {
                 joinPoint.getTarget().getClass());
     }
     public static void errorLog(JoinPoint joinPoint, Throwable e){
-        log.error(DEFAULT_ERROR_MESSAGE_FORMAT, joinPoint.getSignature().toShortString(),
-                e.getMessage(),
-                joinPoint.getTarget().getClass() ,e);
+        log.error(DEFAULT_ERROR_MESSAGE_FORMAT, joinPoint.getSignature().toShortString() ,
+                e.getMessage(), e.getStackTrace()[0], e.getClass().getName());
     }
 
     @Aspect
@@ -42,7 +41,7 @@ public class LayeredArchitectureLogAspect {
             defaultTraceOutputLog(joinPoint, result);
         }
 
-        @AfterThrowing(pointcut = "com.example.base.global.aop.PointCut.allControllerServiceRepositoryUnderBasePackage()", throwing="e")
+        @AfterThrowing(pointcut = "com.example.base.global.aop.PointCut.allControllerUnderBasePackage()", throwing="e")
         public void doAfterThrowing(JoinPoint joinPoint, Throwable e){
             errorLog(joinPoint, e);
         }

--- a/src/main/java/com/example/base/global/exception/ApplicationException.java
+++ b/src/main/java/com/example/base/global/exception/ApplicationException.java
@@ -22,6 +22,7 @@ public class ApplicationException extends RuntimeException implements ErrorRespo
     }
 
     public ApplicationException(String message, Throwable cause){
+        super(message, cause);
         this.httpStatus = HttpStatus.INTERNAL_SERVER_ERROR;
         this.body = ProblemDetail.forStatusAndDetail(getStatusCode(), message);
         this.body.setTitle(DEFAULT_DETAIL);

--- a/src/main/java/com/example/base/global/exception/ApplicationException.java
+++ b/src/main/java/com/example/base/global/exception/ApplicationException.java
@@ -1,0 +1,40 @@
+package com.example.base.global.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.ProblemDetail;
+import org.springframework.web.ErrorResponse;
+
+
+public class ApplicationException extends RuntimeException implements ErrorResponse {
+    private HttpStatus httpStatus;
+    private final ProblemDetail body ;
+    private final static String DEFAULT_DETAIL = "Application exception occurred";
+    private final static String TILE = "Application exception";
+    private final Throwable originCause;
+
+    public ApplicationException(String message){
+        this(message, null);
+    }
+
+    public ApplicationException(Throwable cause){
+        this(DEFAULT_DETAIL, cause);
+    }
+
+    public ApplicationException(String message, Throwable cause){
+        this.httpStatus = HttpStatus.INTERNAL_SERVER_ERROR;
+        this.body = ProblemDetail.forStatusAndDetail(getStatusCode(), message);
+        this.body.setTitle(DEFAULT_DETAIL);
+        this.originCause = cause;
+    }
+
+    @Override
+    public HttpStatusCode getStatusCode() {
+        return this.httpStatus;
+    }
+
+    @Override
+    public ProblemDetail getBody() {
+        return this.body;
+    }
+}

--- a/src/main/java/com/example/base/global/exception/UnknownException.java
+++ b/src/main/java/com/example/base/global/exception/UnknownException.java
@@ -20,7 +20,7 @@ public class UnknownException extends RuntimeException implements ErrorResponse 
     }
 
     public UnknownException(String message, Throwable cause){
-        super(cause);
+        super(message, cause);
         this.httpStatus = HttpStatus.INTERNAL_SERVER_ERROR;
         this.body = ProblemDetail.forStatusAndDetail(getStatusCode(), message);
         this.body.setTitle(DEFAULT_DETAIL);

--- a/src/main/java/com/example/base/global/exception/UnknownException.java
+++ b/src/main/java/com/example/base/global/exception/UnknownException.java
@@ -1,0 +1,39 @@
+package com.example.base.global.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.ProblemDetail;
+import org.springframework.web.ErrorResponse;
+
+public class UnknownException extends RuntimeException implements ErrorResponse {
+    private HttpStatus httpStatus;
+    private final ProblemDetail body ;
+    private final static String DEFAULT_DETAIL = "Unchecked exception(fatal) occurred";
+    private final static String TILE = "Unknown exception";
+
+    public UnknownException(String message){
+        this(message, null);
+    }
+
+    public UnknownException(Throwable cause){
+        this(DEFAULT_DETAIL, cause);
+    }
+
+    public UnknownException(String message, Throwable cause){
+        super(cause);
+        this.httpStatus = HttpStatus.INTERNAL_SERVER_ERROR;
+        this.body = ProblemDetail.forStatusAndDetail(getStatusCode(), message);
+        this.body.setTitle(DEFAULT_DETAIL);
+
+    }
+
+    @Override
+    public HttpStatusCode getStatusCode() {
+        return this.httpStatus;
+    }
+
+    @Override
+    public ProblemDetail getBody() {
+        return this.body;
+    }
+}

--- a/src/main/java/com/example/base/global/filter/GenerateThreadContextIdFilter.java
+++ b/src/main/java/com/example/base/global/filter/GenerateThreadContextIdFilter.java
@@ -1,0 +1,34 @@
+package com.example.base.global.filter;
+
+import jakarta.servlet.*;
+import jakarta.servlet.annotation.WebFilter;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.logging.log4j.ThreadContext;
+import java.io.IOException;
+import java.util.UUID;
+
+@Slf4j
+@WebFilter(urlPatterns = "/*")
+public class GenerateThreadContextIdFilter implements Filter {
+    @Override
+    public void init(FilterConfig filterConfig) throws ServletException {
+        Filter.super.init(filterConfig);
+    }
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
+        if(ThreadContext.isEmpty()) {
+            ThreadContext.put("id", UUID.randomUUID().toString().substring(0,8));
+        }
+
+        chain.doFilter(request, response);
+
+        log.trace("Clear ThreadContext");
+        ThreadContext.clearMap();
+    }
+
+    @Override
+    public void destroy() {
+        Filter.super.destroy();
+    }
+}

--- a/src/main/java/com/example/base/global/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/base/global/handler/GlobalExceptionHandler.java
@@ -1,18 +1,76 @@
 package com.example.base.global.handler;
 
+import com.example.base.global.exception.ApplicationException;
+import com.example.base.global.exception.UnknownException;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
+import org.springframework.context.i18n.LocaleContextHolder;
+import org.springframework.http.*;
+import org.springframework.lang.Nullable;
+import org.springframework.web.ErrorResponse;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.ServletWebRequest;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
 
 @RestControllerAdvice
 @Slf4j
-public class GlobalExceptionHandler {
-    public final static String RUNTIME_EXCEPTION_MESSAGE = "unacceptable exception occurred";
+public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
     @ExceptionHandler(RuntimeException.class)
-    public ResponseEntity runtimeException(RuntimeException e) {
-        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(RUNTIME_EXCEPTION_MESSAGE);
+    public ResponseEntity handleRuntimeException(RuntimeException ex, WebRequest webRequest) {
+        HttpHeaders headers = new HttpHeaders();
+        return handleExceptionInternal(ex, null, headers, HttpStatus.INTERNAL_SERVER_ERROR, webRequest);
+    }
+
+    @Override
+    protected ResponseEntity<Object> handleExceptionInternal(
+            Exception ex, @Nullable Object body, HttpHeaders headers, HttpStatusCode statusCode, WebRequest request) {
+
+        if (request instanceof ServletWebRequest servletWebRequest) {
+            HttpServletResponse response = servletWebRequest.getResponse();
+            if (response != null && response.isCommitted()) {
+                log.warn("Response already committed. Ignoring: {}", ex);
+                return null;
+            }
+        }
+
+        if (statusCode.equals(HttpStatus.INTERNAL_SERVER_ERROR) && body == null && !(ex instanceof ErrorResponse)) {
+            // 때에 따라 github or slack에 publish?
+            // log.error("Fatal error occurred {}", ex.getCause());
+            ex = new UnknownException(ex);
+        }
+
+        if (body == null && ex instanceof ErrorResponse errorResponse) {
+            if(ex instanceof ServletException){
+                errorResponse.getBody().setProperty("code", ExceptionCode.SERVLET_WEB_REQUEST_ERROR_CODE.getExceptionCode());
+            } else if(ex instanceof  ApplicationException){
+                errorResponse.getBody().setProperty("code", ExceptionCode.APPLICATION_ERROR_CODE.getExceptionCode());
+            } else{
+                errorResponse.getBody().setProperty("code", ExceptionCode.FATAL_ERROR_CODE.getExceptionCode());
+            }
+            body = errorResponse.updateAndGetBody(getMessageSource(), LocaleContextHolder.getLocale());
+        }
+
+        return createResponseEntity(body, headers, statusCode, request);
+    }
+
+    private enum ExceptionCode {
+        SERVLET_WEB_REQUEST_ERROR_CODE("EX1"),
+        APPLICATION_ERROR_CODE("EX2"),
+        FATAL_ERROR_CODE("EX3");
+
+        private String exceptionCode;
+
+        ExceptionCode(String exceptionCode){
+            this.exceptionCode = exceptionCode;
+        }
+
+        public String getExceptionCode(){
+            return exceptionCode;
+        }
     }
 }

--- a/src/main/java/com/example/base/global/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/base/global/handler/GlobalExceptionHandler.java
@@ -1,0 +1,18 @@
+package com.example.base.global.handler;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+@Slf4j
+public class GlobalExceptionHandler {
+    public final static String RUNTIME_EXCEPTION_MESSAGE = "unacceptable exception occurred";
+
+    @ExceptionHandler(RuntimeException.class)
+    public ResponseEntity runtimeException(RuntimeException e) {
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(RUNTIME_EXCEPTION_MESSAGE);
+    }
+}

--- a/src/main/java/com/example/base/global/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/base/global/handler/GlobalExceptionHandler.java
@@ -5,6 +5,7 @@ import com.example.base.global.exception.UnknownException;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.logging.log4j.ThreadContext;
 import org.springframework.context.i18n.LocaleContextHolder;
 import org.springframework.http.*;
 import org.springframework.lang.Nullable;
@@ -50,8 +51,10 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
             } else if(ex instanceof  ApplicationException){
                 errorResponse.getBody().setProperty("code", ExceptionCode.APPLICATION_ERROR_CODE.getExceptionCode());
             } else{
+                log.error("[FATAL] {} {}", ex.getMessage(), ex.getStackTrace()[0]);
                 errorResponse.getBody().setProperty("code", ExceptionCode.FATAL_ERROR_CODE.getExceptionCode());
             }
+            errorResponse.getBody().setProperty("uuid", ThreadContext.get("id"));
             body = errorResponse.updateAndGetBody(getMessageSource(), LocaleContextHolder.getLocale());
         }
 

--- a/src/main/java/com/example/base/global/interceptor/LoggingInterceptor.java
+++ b/src/main/java/com/example/base/global/interceptor/LoggingInterceptor.java
@@ -13,9 +13,6 @@ public class LoggingInterceptor implements HandlerInterceptor {
     @Override
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler)
             throws Exception {
-        if(ThreadContext.isEmpty()) {
-            ThreadContext.put("id", UUID.randomUUID().toString().substring(0,8));
-        }
         ThreadContext.put("ipAddress", request.getRemoteAddr());
         ThreadContext.put("hostName", request.getServerName());
 
@@ -30,7 +27,7 @@ public class LoggingInterceptor implements HandlerInterceptor {
         log.info("Response {} {} {} {}",request.getMethod(),
                 request.getRequestURI(), response.getContentType(), response.getStatus());
         log.trace("Clear ThreadContext");
-        ThreadContext.clearMap();
+//        ThreadContext.clearMap();
     }
 
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,10 @@
 spring:
   application:
     name: base
+  mvc:
+    throw-exception-if-no-handler-found: true
+    problemdetails:
+      enabled: true
   docker:
     compose:
       enabled: false

--- a/src/test/integration/java/com/example/base/domain/user/service/UserServiceTest.java
+++ b/src/test/integration/java/com/example/base/domain/user/service/UserServiceTest.java
@@ -1,4 +1,4 @@
-package com.example.base.global.util.generator.domain.user.service;
+package com.example.base.domain.user.service;
 
 import com.example.base.domain.user.domain.User;
 import com.example.base.domain.user.repository.UserRepository;

--- a/src/test/integration/java/com/example/base/global/filter/GenerateThreadContextIdFilterTest.java
+++ b/src/test/integration/java/com/example/base/global/filter/GenerateThreadContextIdFilterTest.java
@@ -1,0 +1,102 @@
+package com.example.base.global.filter;
+
+import org.apache.logging.log4j.ThreadContext;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import java.util.UUID;
+
+import static com.example.base.global.filter.ThreadContextCheckFilter.EMPTY_THREAD_CONTEXT_MESSAGE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+
+public class GenerateThreadContextIdFilterTest {
+    @Nested
+    @WebMvcTest(controllers = {GenerateThreadContextIdTestController.class},
+            properties = {"spring.profiles.active=GENERATE_THREAD_CONTEXT_ID_TEST"})
+    class WithControllerByWebMvcTest {
+        private MockMvc mockMvc; // 특정 filter만을 target으로 하기 위해 Autowired를 사용하지 않음.
+
+        @Autowired
+        protected WebApplicationContext context;
+
+        @AfterEach
+        void afterEach(){
+            mockMvc = null;
+        }
+
+
+        @Test
+        void controller에서_thread_id는_같아야한다() throws Exception {
+            mockMvc = MockMvcBuilders.webAppContextSetup(context)
+                    .addFilters(new GenerateThreadContextIdFilter()).build();
+            String randomId = UUID.randomUUID().toString().substring(0,8);
+
+            ThreadContext.put("id", randomId);
+            mockMvc.perform(get("/foo"))
+                    .andExpect(jsonPath("$").value(randomId));
+        }
+    }
+
+    @Nested
+    @WebMvcTest(controllers = {GenerateThreadContextIdTestController.class},
+            properties = {"spring.profiles.active=GENERATE_THREAD_CONTEXT_ID_TEST"})
+    class WithFilterByWebMvcTest {
+        private MockMvc mockMvc; // 특정 filter만을 target으로 하기 위해 Autowired를 사용하지 않음.
+
+        @Autowired
+        protected WebApplicationContext context;
+
+        @AfterEach
+        void afterEach() {
+            mockMvc = null;
+        }
+
+
+        @Test
+        void controller에서_thread_id는_같아야한다() throws Exception {
+            mockMvc = MockMvcBuilders.webAppContextSetup(context)
+                    .addFilters(new GenerateThreadContextIdFilter()).build();
+            String randomId = UUID.randomUUID().toString().substring(0, 8);
+
+            ThreadContext.put("id", randomId);
+            mockMvc.perform(get("/foo"))
+                    .andExpect(jsonPath("$").value(randomId));
+        }
+
+        @Test
+        void GenerateThreadContextIdFilter가_먼저_결합된_경우_Thread_context에_id가_존재해야한다() {
+            mockMvc = MockMvcBuilders.webAppContextSetup(context)
+                    .addFilters(new GenerateThreadContextIdFilter(), new ThreadContextCheckFilter()).build();
+
+            try {
+                mockMvc.perform(get("/foo")).andExpect(status().isOk());
+                ;
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+
+        }
+
+        @Test
+        void GenerateThreadContextIdFilter가_나중에_결합된_경우_Thread_context에_id가_존재하면_안된다() {
+            mockMvc = MockMvcBuilders.webAppContextSetup(context)
+                    .addFilters(new ThreadContextCheckFilter(), new GenerateThreadContextIdFilter()).build();
+            try {
+                mockMvc.perform(get("/foo"));
+            } catch (RuntimeException e) {
+                assertThat(e.getMessage()).isEqualTo(EMPTY_THREAD_CONTEXT_MESSAGE);
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+}

--- a/src/test/integration/java/com/example/base/global/filter/GenerateThreadContextIdTestController.java
+++ b/src/test/integration/java/com/example/base/global/filter/GenerateThreadContextIdTestController.java
@@ -1,0 +1,20 @@
+package com.example.base.global.filter;
+
+
+import org.apache.logging.log4j.ThreadContext;
+import org.springframework.context.annotation.Profile;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Profile("GENERATE_THREAD_CONTEXT_ID_TEST")
+// 또는 @Conditional 사용
+@RestController
+public class GenerateThreadContextIdTestController {
+
+    @GetMapping("/foo")
+    public ResponseEntity foo() {
+        return ResponseEntity.status(HttpStatus.OK).body(ThreadContext.get("id").toString());
+    }
+}

--- a/src/test/integration/java/com/example/base/global/filter/ThreadContextCheckFilter.java
+++ b/src/test/integration/java/com/example/base/global/filter/ThreadContextCheckFilter.java
@@ -1,0 +1,27 @@
+package com.example.base.global.filter;
+
+import jakarta.servlet.*;
+import org.apache.logging.log4j.ThreadContext;
+import org.springframework.context.annotation.Profile;
+
+import java.io.IOException;
+
+@Profile("GENERATE_THREAD_CONTEXT_ID_TEST")
+public class ThreadContextCheckFilter implements Filter {
+    public final static String EMPTY_THREAD_CONTEXT_MESSAGE = "EMPTY_THREAD_CONTEXT";
+    @Override
+    public void init(FilterConfig filterConfig) throws ServletException {
+        Filter.super.init(filterConfig);
+    }
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
+        if(ThreadContext.isEmpty()) throw new RuntimeException(EMPTY_THREAD_CONTEXT_MESSAGE);
+        chain.doFilter(request, response);
+    }
+
+    @Override
+    public void destroy() {
+        Filter.super.destroy();
+    }
+}

--- a/src/test/integration/java/com/example/base/global/handler/GlobalExceptionHandlerTest.java
+++ b/src/test/integration/java/com/example/base/global/handler/GlobalExceptionHandlerTest.java
@@ -1,0 +1,106 @@
+package com.example.base.global.handler;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static com.example.base.global.handler.GlobalExceptionHandlerTestController.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+public class GlobalExceptionHandlerTest {
+    @Nested
+    class SingleThread {
+        @Nested
+        @DisplayName("ServletException (Only test HttpRequestMethodNotSupportedException )")
+        class ServletExceptionTest {
+            @Nested
+            @DisplayName("HttpRequestMethodNotSupportedException")
+            @WebMvcTest(controllers = GlobalExceptionHandlerTestController.class,
+                    properties = {"spring.profiles.active=test"})
+            @ExtendWith(MockitoExtension.class)
+            class HttpRequestMethodNotSupportedExceptionTest{
+                @Autowired
+                private MockMvc mockMvc;
+
+                @Test
+                void status_405와_message가_와야한다() throws Exception {
+                    mockMvc.perform(get(WRONG_METHOD_URI_WHEN_USE_GET))
+                            .andExpect(status().isMethodNotAllowed());
+                }
+
+                @Test
+                void Response는_RFC7807를_준수해야한다() throws Exception {
+                    mockMvc.perform(get(WRONG_METHOD_URI_WHEN_USE_GET))
+                            .andExpect(jsonPath("$.type").isNotEmpty())
+                            .andExpect(jsonPath("$.title").isNotEmpty())
+                            .andExpect(jsonPath("$.status").isNotEmpty())
+                            .andExpect(jsonPath("$.detail").isNotEmpty());
+                }
+
+                @Test
+                void Response의_code는_EX2여야한다() throws Exception {
+                    mockMvc.perform(get(APPLICATION_EXCEPTION_URI))
+                            .andExpect(jsonPath("$.code").isNotEmpty())
+                            .andExpect(jsonPath("$.code").value("EX2"));
+                }
+            }
+        }
+
+        @Nested
+        @DisplayName("CustomException")
+        class CustomExceptionTest {
+
+            @Nested
+            @DisplayName("ApplicationException")
+            @WebMvcTest(controllers = GlobalExceptionHandlerTestController.class,
+                    properties = {"spring.profiles.active=test"})
+            @ExtendWith(MockitoExtension.class)
+            class ApplicationExceptionTest {
+                @Autowired
+                private MockMvc mockMvc;
+
+                @Test
+                void Response는_RFC7807를_준수해야한다() throws Exception {
+                    mockMvc.perform(get(APPLICATION_EXCEPTION_URI))
+                            .andExpect(jsonPath("$.type").isNotEmpty())
+                            .andExpect(jsonPath("$.title").isNotEmpty())
+                            .andExpect(jsonPath("$.status").isNotEmpty())
+                            .andExpect(jsonPath("$.detail").isNotEmpty());
+                }
+
+                @Test
+                void Response의_code는_EX2여야한다() throws Exception {
+                    mockMvc.perform(get(APPLICATION_EXCEPTION_URI))
+                            .andExpect(jsonPath("$.code").isNotEmpty())
+                            .andExpect(jsonPath("$.code").value("EX2"));
+                }
+            }
+        }
+
+        @Nested
+        @DisplayName("RuntimeException")
+        @WebMvcTest(controllers = GlobalExceptionHandlerTestController.class,
+                properties = {"spring.profiles.active=test"})
+        @ExtendWith(MockitoExtension.class)
+        class RuntimeExceptionTest {
+            @Autowired
+            private MockMvc mockMvc;
+
+            @Test
+            void Response는_RFC7807를_준수해야한다() throws Exception {
+                mockMvc.perform(get(RUNTIME_EXCEPTION_URI))
+                        .andExpect(jsonPath("$.type").isNotEmpty())
+                        .andExpect(jsonPath("$.title").isNotEmpty())
+                        .andExpect(jsonPath("$.status").isNotEmpty())
+                        .andExpect(jsonPath("$.detail").isNotEmpty());
+            }
+        }
+    }
+
+}

--- a/src/test/integration/java/com/example/base/global/handler/GlobalExceptionHandlerTestController.java
+++ b/src/test/integration/java/com/example/base/global/handler/GlobalExceptionHandlerTestController.java
@@ -1,0 +1,38 @@
+package com.example.base.global.handler;
+
+import com.example.base.global.exception.ApplicationException;
+import org.springframework.context.annotation.Profile;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@Profile("test")
+public class GlobalExceptionHandlerTestController {
+    public static final String GET_RESPONSE_BODY = "test";
+    public static final String GET_MAPPING_URI = "/simple-test-controller/get";
+    public static final String WRONG_METHOD_URI_WHEN_USE_GET = "/simple-test-controller/wrong-method-use-get";
+    public static final String APPLICATION_EXCEPTION_URI = "/simple-test-controller/application-exception";
+    public static final String RUNTIME_EXCEPTION_URI = "/simple-test-controller/runtime-exception";
+    @GetMapping(GET_MAPPING_URI)
+    public ResponseEntity get(){
+        return ResponseEntity.status(HttpStatus.OK).body(GET_RESPONSE_BODY);
+    }
+
+    @PostMapping(WRONG_METHOD_URI_WHEN_USE_GET)
+    public ResponseEntity wrongMethodURI_WHEN_USE_GET(){
+        return ResponseEntity.status(HttpStatus.OK).body(GET_RESPONSE_BODY);
+    }
+
+    @GetMapping(APPLICATION_EXCEPTION_URI)
+    public ResponseEntity applicationException() throws ApplicationException {
+        throw new ApplicationException("message");
+    }
+
+    @GetMapping(RUNTIME_EXCEPTION_URI)
+    public ResponseEntity runtimeException() throws ApplicationException {
+        throw new RuntimeException("message");
+    }
+}

--- a/src/test/integration/java/test/util/WithContextControllerTestBase.java
+++ b/src/test/integration/java/test/util/WithContextControllerTestBase.java
@@ -11,9 +11,12 @@ import org.springframework.transaction.annotation.Transactional;
 
 @SpringBootTest
 @Disabled
-@AutoConfigureMockMvc // @SpringTest와 WebMvc를 사용하는 경우 사용. @WebMvcTest과 함께 쓰면 충돌
+// Servlet container mocking
+// @SpringTest와 WebMvc를 사용하는 경우 사용. @WebMvcTest과 함께 쓰면 각자 서로의 MockMvc를 모킹하려 하기 때문에 충돌
+// @WebMvc는 타겟 클래스만 인스턴스화 하지만 @AuthConfigureMockMvc는 관련 service, repository 모두 인스턴스화.
+@AutoConfigureMockMvc
 @Transactional
-public class BaseIntegrationTest {
+public class WithContextControllerTestBase {
     @Autowired
     protected MockMvc mockMvc;
 

--- a/src/test/unit/java/test/unit/com/example/base/global/exception/ApplicationExceptionTest.java
+++ b/src/test/unit/java/test/unit/com/example/base/global/exception/ApplicationExceptionTest.java
@@ -1,0 +1,114 @@
+package test.unit.com.example.base.global.exception;
+
+import com.example.base.global.exception.ApplicationException;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.*;
+import org.springframework.http.HttpStatus;
+
+public class ApplicationExceptionTest {
+    @Nested
+    class SingleThread {
+        @Nested
+        @DisplayName("ApplicationException(String message) 생성자로 생성한 경우")
+        class ExceptionWithMessage {
+            private final String exceptionMessageForWithMessage = "withMessage";
+            ApplicationException applicationExceptionWithMessage;
+            @BeforeEach()
+            void beforeEach(){
+                applicationExceptionWithMessage = new ApplicationException(exceptionMessageForWithMessage);
+            }
+
+            @Test
+            void 생성_시_status_code_는_500이어야한다(){
+                Assertions.assertAll(
+                        ()-> assertThat(applicationExceptionWithMessage.getBody().getStatus()).isEqualTo(500),
+                        ()-> assertThat(applicationExceptionWithMessage.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR)
+                );
+            }
+
+            @Test
+            void Message만으로_생성_시_detail은_message여야_한다(){
+                assertThat(applicationExceptionWithMessage.getBody().getDetail()).isEqualTo(exceptionMessageForWithMessage);
+            }
+
+            @Test
+            void Message만으로_생성_시_Body의_instance는_비어있어야한다(){
+                assertThat(applicationExceptionWithMessage.getBody().getInstance()).isNull();
+            }
+        }
+
+        @Nested
+        @DisplayName("ApplicationException(Throwable cause) 생성자로 생성한 경우")
+        class ExceptionWithOriginException {
+            private final String exceptionMessageForWithException = "withException";
+            private final String exceptionMessageForRuntimeException = "Origin";
+
+            ApplicationException applicationExceptionWithException;
+            RuntimeException runtimeException1;
+            RuntimeException runtimeException2;
+
+
+            @BeforeEach()
+            void beforeEach(){
+                runtimeException1 = new RuntimeException();
+                runtimeException2 = new RuntimeException(exceptionMessageForRuntimeException);
+                applicationExceptionWithException = new ApplicationException(exceptionMessageForWithException);
+
+            }
+
+            @Test
+            void 생성_시_status_code_는_500이어야한다(){
+                Assertions.assertAll(
+                        ()-> assertThat(applicationExceptionWithException.getBody().getStatus()).isEqualTo(500),
+                        ()-> assertThat(applicationExceptionWithException.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR)
+                );
+            }
+
+            @Test
+            void Exception으로_생성_시_detail은_null이면_안된다(){
+                assertThat(applicationExceptionWithException.getBody().getDetail()).isNotNull();
+            }
+
+            @Test
+            void Exception으로_생성_시_Body의_instance는_비어있어야한다(){
+                assertThat(applicationExceptionWithException.getBody().getInstance()).isNull();
+            }
+        }
+
+        @Nested
+        @DisplayName("ApplicationException(String message, Throwable Cause) 생성자로 생성한 경우")
+        class ExceptionWithMessageAndOriginException {
+            private final String exceptionMessageForRuntimeException = "Origin";
+            private final String exceptionMessageForWithMessageAndException = "withMessageAndException";
+
+            ApplicationException applicationExceptionWithMessageAndException;
+            RuntimeException runtimeException1;
+            RuntimeException runtimeException2;
+
+
+            @BeforeEach()
+            void beforeEach(){
+                runtimeException1 = new RuntimeException();
+                runtimeException2 = new RuntimeException(exceptionMessageForRuntimeException);
+
+                applicationExceptionWithMessageAndException =
+                        new ApplicationException(exceptionMessageForWithMessageAndException, runtimeException2);
+
+            }
+
+            @Test
+            void 생성_시_status_code_는_500이어야한다(){
+                Assertions.assertAll(
+                        ()-> assertThat(applicationExceptionWithMessageAndException.getBody().getStatus()).isEqualTo(500),
+                        ()-> assertThat(applicationExceptionWithMessageAndException.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR)
+                );
+            }
+
+            @Test
+            void Message와_exception으로_생성_시_detail은_message여야_한다(){
+                assertThat(applicationExceptionWithMessageAndException.getBody().getDetail()).isEqualTo(exceptionMessageForWithMessageAndException);
+            }
+        }
+    }
+}

--- a/src/test/unit/java/test/unit/com/example/base/global/exception/UnknownExceptionTest.java
+++ b/src/test/unit/java/test/unit/com/example/base/global/exception/UnknownExceptionTest.java
@@ -1,0 +1,115 @@
+package test.unit.com.example.base.global.exception;
+
+import com.example.base.global.exception.UnknownException;
+import org.junit.jupiter.api.*;
+import org.springframework.http.HttpStatus;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class UnknownExceptionTest {
+    @Nested
+    class SingleThread {
+        @Nested
+        @DisplayName("UnknownException(String message) 생성자로 생성한 경우")
+        class ExceptionWithMessage {
+            private final String exceptionMessageForWithMessage = "withMessage";
+            UnknownException unknownExceptionWithMessage;
+
+            @BeforeEach()
+            void beforeEach() {
+                unknownExceptionWithMessage = new UnknownException(exceptionMessageForWithMessage);
+            }
+
+            @Test
+            void 생성_시_status_code_는_500이어야한다() {
+                Assertions.assertAll(
+                        () -> assertThat(unknownExceptionWithMessage.getBody().getStatus()).isEqualTo(500),
+                        () -> assertThat(unknownExceptionWithMessage.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR)
+                );
+            }
+
+            @Test
+            void Message만으로_생성_시_detail은_message여야_한다() {
+                assertThat(unknownExceptionWithMessage.getBody().getDetail()).isEqualTo(exceptionMessageForWithMessage);
+            }
+
+            @Test
+            void Message만으로_생성_시_Body의_instance는_비어있어야한다() {
+                assertThat(unknownExceptionWithMessage.getBody().getInstance()).isNull();
+            }
+        }
+
+        @Nested
+        @DisplayName("UnknownException(Throwable cause) 생성자로 생성한 경우")
+        class ExceptionWithOriginException {
+            private final String exceptionMessageForWithException = "withException";
+            private final String exceptionMessageForRuntimeException = "Origin";
+
+            UnknownException unknownExceptionWithException;
+            RuntimeException runtimeException1;
+            RuntimeException runtimeException2;
+
+
+            @BeforeEach()
+            void beforeEach() {
+                runtimeException1 = new RuntimeException();
+                runtimeException2 = new RuntimeException(exceptionMessageForRuntimeException);
+                unknownExceptionWithException = new UnknownException(exceptionMessageForWithException);
+
+            }
+
+            @Test
+            void 생성_시_status_code_는_500이어야한다() {
+                Assertions.assertAll(
+                        () -> assertThat(unknownExceptionWithException.getBody().getStatus()).isEqualTo(500),
+                        () -> assertThat(unknownExceptionWithException.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR)
+                );
+            }
+
+            @Test
+            void Exception으로_생성_시_detail은_null이면_안된다() {
+                assertThat(unknownExceptionWithException.getBody().getDetail()).isNotNull();
+            }
+
+            @Test
+            void Exception으로_생성_시_Body의_instance는_비어있어야한다() {
+                assertThat(unknownExceptionWithException.getBody().getInstance()).isNull();
+            }
+        }
+
+        @Nested
+        @DisplayName("UnknownException(String message, Throwable Cause) 생성자로 생성한 경우")
+        class ExceptionWithMessageAndOriginException {
+            private final String exceptionMessageForRuntimeException = "Origin";
+            private final String exceptionMessageForWithMessageAndException = "withMessageAndException";
+
+            UnknownException unknownExceptionWithMessageAndException;
+            RuntimeException runtimeException1;
+            RuntimeException runtimeException2;
+
+
+            @BeforeEach()
+            void beforeEach() {
+                runtimeException1 = new RuntimeException();
+                runtimeException2 = new RuntimeException(exceptionMessageForRuntimeException);
+
+                unknownExceptionWithMessageAndException =
+                        new UnknownException(exceptionMessageForWithMessageAndException, runtimeException2);
+
+            }
+
+            @Test
+            void 생성_시_status_code_는_500이어야한다() {
+                Assertions.assertAll(
+                        () -> assertThat(unknownExceptionWithMessageAndException.getBody().getStatus()).isEqualTo(500),
+                        () -> assertThat(unknownExceptionWithMessageAndException.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR)
+                );
+            }
+
+            @Test
+            void Message와_exception으로_생성_시_detail은_message여야_한다() {
+                assertThat(unknownExceptionWithMessageAndException.getBody().getDetail()).isEqualTo(exceptionMessageForWithMessageAndException);
+            }
+        }
+    }
+}

--- a/src/test/unit/java/test/unit/com/example/base/global/filter/GenerateThreadContextIdFilterTest.java
+++ b/src/test/unit/java/test/unit/com/example/base/global/filter/GenerateThreadContextIdFilterTest.java
@@ -1,0 +1,48 @@
+package test.unit.com.example.base.global.filter;
+
+import com.example.base.global.filter.GenerateThreadContextIdFilter;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import org.apache.logging.log4j.ThreadContext;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import static org.mockito.Mockito.*;
+
+import java.io.IOException;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.UUID;
+
+public class GenerateThreadContextIdFilterTest {
+
+    @Test
+    void filter는_전역적으로_적용되어야_한다() throws ServletException, IOException {
+        var request = new MockHttpServletRequest();
+        var response = new MockHttpServletResponse();
+        var filterChain = mock(FilterChain.class);
+        var generateThreadContextIdFilter = new GenerateThreadContextIdFilter();
+
+        request.setRequestURI("/"+ UUID.randomUUID().toString());
+
+        generateThreadContextIdFilter.doFilter(request, response, filterChain);
+
+        verify(filterChain, times(1)).doFilter(request, response);
+    }
+
+    @Test
+    void 요청이_끝나면_Thread_Context는_초기화되어야한다() throws ServletException, IOException {
+        var request = new MockHttpServletRequest();
+        var response = new MockHttpServletResponse();
+        var filterChain = mock(FilterChain.class);
+        var generateThreadContextIdFilter = new GenerateThreadContextIdFilter();
+
+        String randomId = UUID.randomUUID().toString().substring(0,8);
+        ThreadContext.put("id", randomId);
+
+        request.setRequestURI("/"+ UUID.randomUUID().toString());
+
+        generateThreadContextIdFilter.doFilter(request, response, filterChain);
+        assertThat(ThreadContext.isEmpty()).isTrue();
+    }
+}

--- a/src/test/unit/java/test/unit/com/example/base/global/handler/GlobalExceptionHandlerTest.java
+++ b/src/test/unit/java/test/unit/com/example/base/global/handler/GlobalExceptionHandlerTest.java
@@ -1,28 +1,63 @@
 package test.unit.com.example.base.global.handler;
 
+import com.example.base.global.exception.ApplicationException;
+import com.example.base.global.exception.UnknownException;
 import com.example.base.global.handler.GlobalExceptionHandler;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.context.request.WebRequest;
 
-import static com.example.base.global.handler.GlobalExceptionHandler.RUNTIME_EXCEPTION_MESSAGE;
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.*;
 
 public class GlobalExceptionHandlerTest {
+    @Nested
+    class SingleThread{
+        @Mock
+        HttpHeaders httpHeaders;
 
-    @Test
-    public void 런타임_exception이_발생하면_status_500과_미리_정의된_메세지가_돌아와야한다() {
-        // given
-        GlobalExceptionHandler globalExceptionHandler = new GlobalExceptionHandler();
-        final String exceptionMessage = "Exception occurred";
-        RuntimeException e = new RuntimeException(exceptionMessage);
+        @Mock
+        WebRequest webRequest;
 
-        // when
-        ResponseEntity responseEntity = globalExceptionHandler.runtimeException(e);
+        @Mock
+        HttpStatus givenHttpStatus;
 
-        // then
-        assertThat(responseEntity.getBody()).isEqualTo(RUNTIME_EXCEPTION_MESSAGE);
-        assertThat(responseEntity.getBody()).isNotEqualTo(exceptionMessage);
-        assertThat(responseEntity.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
+        @Test
+        public void RuntimeException이_주어진_경우_직접적으로_핸들링이_가능해야한다() {
+            // given
+            GlobalExceptionHandler globalExceptionHandler = new GlobalExceptionHandler();
+            final String exceptionMessage = "Exception occurred";
+            RuntimeException e = new RuntimeException(exceptionMessage);
+
+            // when
+            ResponseEntity responseEntity = globalExceptionHandler.handleRuntimeException(e, webRequest);
+
+            // then
+            assertThat(responseEntity.getBody()).isNotNull();
+        }
+
+        @Test
+        void ApplicationException이_주어진_경우_직접적으로_핸들링이_가능해야한다() throws Exception{
+            GlobalExceptionHandler globalExceptionHandler = new GlobalExceptionHandler();
+            ApplicationException e = new ApplicationException("");
+
+            ResponseEntity responseEntity = globalExceptionHandler.handleRuntimeException(e, webRequest);
+
+            assertThat(responseEntity.getBody()).isNotNull();
+        }
+
+        @Test
+        void UnknownException이_주어진_경우_직접적으로_핸들링이_가능해야한다() throws Exception{
+            GlobalExceptionHandler globalExceptionHandler = new GlobalExceptionHandler();
+            UnknownException e = new UnknownException("");
+
+
+            ResponseEntity responseEntity = globalExceptionHandler.handleRuntimeException(e, webRequest);
+
+            assertThat(responseEntity.getBody()).isNotNull();
+        }
     }
 }

--- a/src/test/unit/java/test/unit/com/example/base/global/handler/GlobalExceptionHandlerTest.java
+++ b/src/test/unit/java/test/unit/com/example/base/global/handler/GlobalExceptionHandlerTest.java
@@ -1,0 +1,28 @@
+package test.unit.com.example.base.global.handler;
+
+import com.example.base.global.handler.GlobalExceptionHandler;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import static com.example.base.global.handler.GlobalExceptionHandler.RUNTIME_EXCEPTION_MESSAGE;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class GlobalExceptionHandlerTest {
+
+    @Test
+    public void 런타임_exception이_발생하면_status_500과_미리_정의된_메세지가_돌아와야한다() {
+        // given
+        GlobalExceptionHandler globalExceptionHandler = new GlobalExceptionHandler();
+        final String exceptionMessage = "Exception occurred";
+        RuntimeException e = new RuntimeException(exceptionMessage);
+
+        // when
+        ResponseEntity responseEntity = globalExceptionHandler.runtimeException(e);
+
+        // then
+        assertThat(responseEntity.getBody()).isEqualTo(RUNTIME_EXCEPTION_MESSAGE);
+        assertThat(responseEntity.getBody()).isNotEqualTo(exceptionMessage);
+        assertThat(responseEntity.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+}


### PR DESCRIPTION
<!-- 필요한 항목만 작성 -->
## ✨ New features
### Controller advice를 통한 global exception 핸들링
- 전역적인 exception 핸들링
  - Spring context에서 발생하는 exception 핸들링 
  - Dispatcher servlet에서 핸들링하던 servlet exception handling
    - `ResponseEntityExceptionHandler`를 상속
    - spring의 `DefaultHandlerExceptionResolver`가 사용되지 않음

### 모든 exception response 에 대해 [RFC 7870](https://datatracker.ietf.org/doc/html/rfc7807) 적용
- `ResponseEntityExceptionHandler`의 `handleExceptionInternal()`를 override하여 모든 exception에 대한 body 작성
  - `ProblemDetail`의 메소드를 이용하여 body 구성
  -  `ErrorResponse` 의 `ProblemDetail`는 [RFC 7870](https://datatracker.ietf.org/doc/html/rfc7807)에 맞는 response body를 구성하기 위한 클래스
- Property 구성
  - code : ExceptionCode부여
    - `SERVLET_WEB_REQUEST_ERROR_CODE("EX1")`
    - `APPLICATION_ERROR_CODE("EX2")`
    - `FATAL_ERROR_CODE("EX3")`

### 확장 가능한 custom exception
- ApplicationException을 
- `ApplicationException` 상속하여 확장 가능
  - 해당 Exception을 상속받아 method들을 override하여 다른 custom exception 작성 가능
- `ApplicationException`은  `RuntimeException`을 상속
  - ControllerAdvice(`GlobalExceptionHandler.class`)에서 처리됨
- `ApplicationException`을 상속하는 class의 경우 response body의 code영역에 application error code가 자동으로 부여됨

## 🐛 Fix
### Logging AOP의 Point  cut 조건이 잘못되었던 버그 픽스
- 잘못된 조건으로 aop가 작동하지 않았음
- `com.example.base.global.aop.PointCut.allControllerServiceRepositoryUnderBasePackage()`조건 변경으로 버그 픽스
  - 변경 전: `allController()` && `allService()` && allRepository()`
  - 변경 후: `allController()` || `allService()` || allRepository()`

## ✏️ Changed
### AOP 어노테이션 변경
- AOP 어노테이션 변경
  - 기존
    - `@Around`를 통해 로깅
    - `@Around` 내 try - catch 블록에서 에러 처리
  - 변경
    - `@Around` 삭제, `@AfterReturning/Throwing`, `@Before`를 통해 로깅
    - 에러를 처리하지 않고 throw (`@AfterThrowing`의 특성)
- 에러 로깅 시 controller에서만 로그를 찍도록 변경
- 에러 로그 양식 변경
```java
private static String DEFAULT_ERROR_MESSAGE_FORMAT = "[{}] {} :: {} {}";

log.error(DEFAULT_ERROR_MESSAGE_FORMAT, joinPoint.getSignature().toShortString() ,
                e.getMessage(), e.getStackTrace()[0], e.getClass().getName());
```
### Thread context에 id 저장 시점 변경
- [GenerateThreadContextIdFilter에서 Thread context에 id 부여](https://github.com/can019/spring-base/pull/19/commits/8e4f1f792c74b4bdee10e470d24ea1623e12371e)
- 더 이상 `LoggingInterceptor`에서 부여하지 않음


## ETC
### Reference
- PR #16, #19, #20
- Issue #17, #18 