### PR TITLE
fix: Github page ui

### DIFF
--- a/.github/scripts/link_develop_docs.py
+++ b/.github/scripts/link_develop_docs.py
@@ -16,11 +16,13 @@ latest_pattern = r"### Latest\n(.+?)(?=\n- - -)"
 other_pattern = r"### Other\n(.+?)(?=\n- - -)"
 
 
+
 def init_develop_markdown():
     develop_config = get_config_by_name("develop", global_config.get("main"))
     description = develop_config.get("description")
     content = f"## develop\n### description\n{description}\n\n"
-    content += "### Latest\n- - - \n### Other\n- - - \n"
+    content += "### Latest\n<!-- Latest -->\n\n"
+    content += "### Other\n<!-- Other --> \n\n"
 
     create_markdown_file('/'.join([root_dir,"develop","index.md"]), content)
 
@@ -30,12 +32,11 @@ def update_develop_markdown(text):
         init_develop_markdown()
 
     latest_line = find_line_number(develop_markdown_path,"## Latest")
-    latest_end_line =  find_line_number(develop_markdown_path,"- - -", start_line=latest_line)
+    latest_end_line =  find_line_number(develop_markdown_path,"<!-- Latest -->", start_line=latest_line)
 
     other_line = find_line_number(develop_markdown_path,"### Other")
-    other_end_line =  find_line_number(develop_markdown_path,"- - -", start_line = other_line)
 
-    if latest_end_line - latest_line is 1 :
+    if latest_end_line - latest_line == 1 :
         # 현재 Latest가 비어있는 경우
         add_line_to_file(develop_markdown_path, latest_line +1 , text)
     else:


### PR DESCRIPTION

## 🐛 Fix
### UI 깨짐 fix
- 로컬 지킬에서는  `- - -` 구분자가 정상적으로 작동했지만 GitHub Pages 지킬에서는 작동하지 않는 문제
- 구분자 제거, html 주석을 추가하여 python script가 주석을 패턴으로 사용할 수 있게 적용

### 📸  Screen Shot
#### Before
<img width="470" alt="스크린샷 2024-06-18 오전 12 41 39" src="https://github.com/can019/spring-base/assets/26926966/bda12226-2558-48ca-a08f-7fca385a6bde">

#### After
<img width="498" alt="스크린샷 2024-06-18 오전 12 46 36" src="https://github.com/can019/spring-base/assets/26926966/b248ce9d-1976-472c-ae59-473ce36129c8">

> commit id가 같은 것은 임의로 데이터를 추가했기 때문