### PR TITLE
fix: Integration coverage jacoco

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
         run: ./gradlew unitTestJacocoReport
 
       - name: Generate integration jacoco report
-        run: ./gradlew unitTestJacocoReport
+        run: ./gradlew integrationTestJacocoReport
 
       - name: Generate over all jacoco report
         run: ./gradlew overAllJacocoTestReport

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,7 +145,7 @@ jobs:
           echo "[Unit](/unit/index.html) | [Integration](integrationTest/index.html)" >> docs/develop/$COMMIT_ID/tests/index.md
           
           echo "## Coverage reports" > docs/develop/$COMMIT_ID/jacoco/index.md
-          echo "[Total](total/html/index.html)  | [Unit](unit/html/index.html) | [Integration](integrationTest/html/index.html)" >> docs/develop/$COMMIT_ID/tests/index.md
+          echo "[Total](total/html/index.html)  | [Unit](unitTest/html/index.html) | [Integration](integrationTest/html/index.html)" >> docs/develop/$COMMIT_ID/jacoco/index.md
 
           ls build/reports/tests
           rm -rf build/reports


### PR DESCRIPTION
## 🐛 Fix
### Integration coverage 측정 명령어 수정
- Unit test coverage로 되어있던 버그 픽스

### Jacoco report docs 구성 시 link가 잘못되게 설정되는 버그 픽스
- Link가 tests/index.md 에 삽입되던 버그 픽스

