### PR TITLE
refactor: User.getId()를 String 반환으로 변경

### DIFF
--- a/src/main/java/com/example/base/domain/user/controller/UserController.java
+++ b/src/main/java/com/example/base/domain/user/controller/UserController.java
@@ -37,7 +37,7 @@ public class UserController {
     public ResponseEntity findOneById(@RequestParam String id){
         User user = this.userService.findOneById(id);
         Map<String, String> body = new HashMap<>();
-        body.put("id", user.getIdAsString());
+        body.put("id", user.getId());
 
         return new ResponseEntity(body, HttpStatus.OK);
     }

--- a/src/main/java/com/example/base/domain/user/domain/User.java
+++ b/src/main/java/com/example/base/domain/user/domain/User.java
@@ -20,11 +20,12 @@ public class User extends BaseTimeEntity {
     )
     private byte[] id;
 
-    public byte[] getId() {
-        return this.id;
+
+    public String getId() {
+        return byteArrayToHexString(this.id);
     }
 
-    public String getIdAsString() {
-        return byteArrayToHexString(getId());
+    public byte[] getIdAsHexByte(){
+        return this.id;
     }
 }

--- a/src/main/java/com/example/base/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/example/base/domain/user/repository/UserRepository.java
@@ -7,6 +7,8 @@ import jakarta.persistence.PersistenceContext;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 
+import static com.example.base.global.util.convertor.TypeConvertor.hexStringToByte;
+
 @Repository
 public class UserRepository  {
 
@@ -20,8 +22,13 @@ public class UserRepository  {
     }
 
     @Transactional
-    public User findOneById(byte[] id){
+    public User findOneById(String strId){
+        byte[] id = this.stringIdToByte(strId);
         return em.find(User.class, id);
     }
 
+    public byte[] stringIdToByte(String strId) {
+        byte[] id = hexStringToByte(strId);
+        return id;
+    }
 }

--- a/src/main/java/com/example/base/domain/user/service/UserService.java
+++ b/src/main/java/com/example/base/domain/user/service/UserService.java
@@ -24,13 +24,12 @@ public class UserService {
     @Transactional
     public String createUser(User user){
         this.userRepository.save(user);
-        String id = user.getIdAsString();
+        String id = user.getId();
         return id;
     }
 
     @Transactional
-    public User findOneById(String strId) {
-        byte[] id = hexStringToByte(strId);
+    public User findOneById(String id) {
         return this.userRepository.findOneById(id);
     }
 }

--- a/src/test/integration/java/com/example/base/domain/user/controller/UserControllerTest.java
+++ b/src/test/integration/java/com/example/base/domain/user/controller/UserControllerTest.java
@@ -30,9 +30,9 @@ public class UserControllerTest extends WithContextControllerTestBase {
         JSONParser jsonParser = new JSONParser();
         JSONObject json = (JSONObject)jsonParser.parse(mvcResult.getResponse().getContentAsString());
 
-        byte[] id = hexStringToByte((String) json.get("id"));
+        String id = (String) json.get("id");
 
-        User user = em.find(User.class, id);
+        User user = em.find(User.class, hexStringToByte(id));
         assertThat(user.getId()).isEqualTo(id);
     }
 
@@ -44,9 +44,9 @@ public class UserControllerTest extends WithContextControllerTestBase {
         em.flush();
 
         mockMvc.perform(get("/user")
-                        .param("id", byteArrayToHexString(user.getId())))
+                        .param("id", user.getId()))
                         .andExpect(status().isOk())
-                        .andExpect(jsonPath("$.id").value(user.getIdAsString()));
+                        .andExpect(jsonPath("$.id").value(user.getId()));
     }
 
     @Test

--- a/src/test/integration/java/com/example/base/domain/user/repository/UserRepositoryTest.java
+++ b/src/test/integration/java/com/example/base/domain/user/repository/UserRepositoryTest.java
@@ -34,7 +34,7 @@ public class UserRepositoryTest {
         User savedUser = userRepository.save(user);
 
         List<User> userList= em.createQuery("select u from User as u where u.id = :userId", User.class)
-                .setParameter("userId", user.getId()).getResultList();
+                .setParameter("userId", user.getIdAsHexByte()).getResultList();
 
         assertThat(savedUser.getId()).isEqualTo(user.getId());
         assertThat(userList.size()).isEqualTo(1);

--- a/src/test/integration/java/com/example/base/domain/user/service/UserServiceTest.java
+++ b/src/test/integration/java/com/example/base/domain/user/service/UserServiceTest.java
@@ -31,7 +31,7 @@ public class UserServiceTest {
     void createAndReadUser() {
         User user = new User();
         String savedId = userService.createUser(user);
-        userRepository.findOneById(savedId.getBytes());
-        assertEquals(savedId, TypeConvertor.byteArrayToHexString(user.getId()));
+        userRepository.findOneById(savedId);
+        assertEquals(savedId, user.getId());
     }
 }

--- a/src/test/unit/java/com/example/base/domain/user/controller/UserControllerTest.java
+++ b/src/test/unit/java/com/example/base/domain/user/controller/UserControllerTest.java
@@ -60,7 +60,7 @@ public class UserControllerTest {
         byte[] id = hexStringToByte(strId);
         User user = mock(User.class);
 
-        when(user.getIdAsString()).thenReturn(strId);
+        when(user.getId()).thenReturn(strId);
         when(userService.findOneById(strId)).thenReturn(user);
 
         mockMvc.perform(get("/user").param("id", strId))

--- a/src/test/unit/java/com/example/base/domain/user/service/UserServiceTest.java
+++ b/src/test/unit/java/com/example/base/domain/user/service/UserServiceTest.java
@@ -25,21 +25,16 @@ public class UserServiceTest {
     void findOneByIDSpyOn (){
         // given
         String strId = "testasdf";
-        byte[] id = strId.getBytes();
         User user = mock(User.class);
-        when(userRepository.findOneById(id)).thenReturn(user);
-        when(user.getId()).thenReturn(id);
 
-        try (MockedStatic typeConvertor = mockStatic(TypeConvertor.class)){
-            typeConvertor.when(()->TypeConvertor.hexStringToByte(Mockito.any())).thenReturn(id);
+        when(userRepository.findOneById(strId)).thenReturn(user);
+        when(user.getId()).thenReturn(strId);
 
             User readUser = userService.findOneById(strId);
 
             //then
             assertThat(readUser.getId()).isEqualTo(user.getId());
-            typeConvertor.verify(()-> TypeConvertor.hexStringToByte(strId), times(1));
-            verify(userRepository, times(1)).findOneById(id);
-        }
+            verify(userRepository, times(1)).findOneById(strId);
     }
 
 }


### PR DESCRIPTION
## ✏️ Changed
###  User.getId()를 String 반환으로 변경
  - bytes[] id가 hex array이기 때문에 getId()-> getBytes() 호출 시 side effect 방지
