### PR TITLE
fix: Lombok annotation을 test에서 사용 가능하도록 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,8 +25,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-devtools'
 	implementation 'com.fasterxml.uuid:java-uuid-generator:5.0.0'
-	compileOnly 'org.projectlombok:lombok'
-	annotationProcessor 'org.projectlombok:lombok'
+
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	runtimeOnly 'com.h2database:h2'
@@ -38,7 +37,9 @@ dependencies {
 	// docker compose
 	testAndDevelopmentOnly("org.springframework.boot:spring-boot-docker-compose")
 
-	// 테스트에서 lombok 사용
+	// lombok
+	compileOnly 'org.projectlombok:lombok'
+	annotationProcessor 'org.projectlombok:lombok'
 	testCompileOnly 'org.projectlombok:lombok'
 	testAnnotationProcessor 'org.projectlombok:lombok'
 
@@ -58,6 +59,7 @@ dependencies {
 configurations {
 	compileOnly {
 		extendsFrom annotationProcessor
+		extendsFrom testAnnotationProcessor
 	}
 	integrationTestImplementation.extendsFrom implementation
 	integrationTestImplementation.extendsFrom testImplementation
@@ -66,6 +68,12 @@ configurations {
 	unitTestImplementation.extendsFrom implementation
 	unitTestImplementation.extendsFrom testImplementation
 	unitTestRuntimeOnly.extendsFrom testRuntimeOnly
+
+	unitTestCompileOnly.extendsFrom testCompileOnly
+	unitTestAnnotationProcessor.extendsFrom testAnnotationProcessor
+	integrationTestCompileOnly.extendsFrom testCompileOnly
+	integrationTestAnnotationProcessor.extendsFrom testAnnotationProcessor
+
 }
 
 sourceSets {
@@ -96,6 +104,9 @@ tasks.withType(Test){
 }
 
 task integrationTest(type: Test) {
+    description = 'Integration test' // 태스크 설명
+	group = 'test'
+
 	testClassesDirs = sourceSets.integrationTest.output.classesDirs
 	classpath = sourceSets.integrationTest.runtimeClasspath
 	jacoco {
@@ -104,6 +115,9 @@ task integrationTest(type: Test) {
 }
 
 task unitTest(type: Test) {
+	description = 'Unit test' // 태스크 설명
+	group = 'test'
+
 	testClassesDirs = sourceSets.unitTest.output.classesDirs
 	classpath = sourceSets.unitTest.runtimeClasspath
 	jacoco {

--- a/src/integration/java/com/github/can019/test/dependency/lombok/LombokAnnotationTest.java
+++ b/src/integration/java/com/github/can019/test/dependency/lombok/LombokAnnotationTest.java
@@ -1,0 +1,17 @@
+package com.github.can019.test.dependency.lombok;
+
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Slf4j
+public class LombokAnnotationTest {
+
+    @Test
+    @DisplayName("Integration test의 test code에서 `@Slf4j`를 사용할 수 있어야 한다")
+    void lombokSlf4jAvailableTest(){
+        assertThat(log).isNotNull();
+    }
+}

--- a/src/unit/java/com/github/can019/test/dependency/lombok/LombokAnnotationTest.java
+++ b/src/unit/java/com/github/can019/test/dependency/lombok/LombokAnnotationTest.java
@@ -1,0 +1,17 @@
+package com.github.can019.test.dependency.lombok;
+
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Slf4j
+public class LombokAnnotationTest {
+
+    @Test
+    @DisplayName("Integration test의 test code에서 `@Slf4j`를 사용할 수 있어야 한다")
+    void lombokSlf4jAvailableTest(){
+        assertThat(log).isNotNull();
+    }
+}


### PR DESCRIPTION
## 🐛 Fix
### Lombok annotation을 test에서 사용 가능하도록 설정
```gradle
configurations {
	compileOnly {
		extendsFrom annotationProcessor
		extendsFrom testAnnotationProcessor
	}
	integrationTestImplementation.extendsFrom implementation
	integrationTestImplementation.extendsFrom testImplementation
	integrationTestRuntimeOnly.extendsFrom testRuntimeOnly

	unitTestImplementation.extendsFrom implementation
	unitTestImplementation.extendsFrom testImplementation
	unitTestRuntimeOnly.extendsFrom testRuntimeOnly

	unitTestCompileOnly.extendsFrom testCompileOnly // << added
	unitTestAnnotationProcessor.extendsFrom testAnnotationProcessor // added 
	integrationTestCompileOnly.extendsFrom testCompileOnly // added
	integrationTestAnnotationProcessor.extendsFrom testAnnotationProcessor // added

}
```