### PR TITLE
Spring rest docs

### DIFF
--- a/.github/scripts/add_swagger_url.py
+++ b/.github/scripts/add_swagger_url.py
@@ -1,0 +1,34 @@
+import argparse
+import yaml
+
+# 명령줄 인자 처리
+parser = argparse.ArgumentParser(description='Add a new URL to the Swagger config file.')
+parser.add_argument('-u', '--url', required=True, help='The URL of the API spec file')
+parser.add_argument('-n', '--name', required=True, help='The name of the API')
+parser.add_argument('-f', '--file', required=True, help='The path to the config YAML file')
+args = parser.parse_args()
+
+# 입력받은 config 파일 경로
+config_file_path = args.file
+
+# 기존 config.yaml 파일 읽기
+try:
+    with open(config_file_path, 'r') as file:
+        config = yaml.safe_load(file)
+except FileNotFoundError:
+    print(f"File not found: {config_file_path}")
+    exit(1)
+
+# urls 배열이 존재하지 않으면 생성
+if 'urls' not in config:
+    config['urls'] = []
+
+# 새로운 엔트리를 urls 배열의 맨 앞에 추가
+new_entry = {'url': args.url, 'name': args.name}
+config['urls'].insert(0, new_entry)
+
+# 변경된 설정을 다시 config.yaml 파일에 쓰기
+with open(config_file_path, 'w') as file:
+    yaml.safe_dump(config, file, default_flow_style=False)
+
+print(f"Added {args.url} with name {args.name} to {config_file_path}")

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,10 @@ jobs:
       - name: Generate over all jacoco report
         run: ./gradlew overAllJacocoTestReport
 
+
+      - name: Generate OpenApi3 yml
+        run: ./gradlew openapi3 -x check
+
       - name: Save test reports
         uses: actions/upload-artifact@v4
         with:
@@ -51,6 +55,7 @@ jobs:
           path: |
             build/reports
             build/test-results
+            build/api-spec
 
       - name: Save build
         uses: actions/upload-artifact@v4
@@ -103,12 +108,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-#
-#      - name: Analyze by Sonar-Cloud
-#        run: ./gradlew sonar --info
-#        env:
-#          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-#          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 
   publish-junit-result-pr-comment:
     needs: [build]
@@ -238,6 +237,17 @@ jobs:
           git status
 
           git commit -m "docs: Jacoco reports release $RELEASE_VERSION ($COMMIT_ID)"
+
+      - name: Commit Openapi3 yaml
+        run: |
+          cp -R build/api-spec/openapi3.yaml docs/release/$RELEASE_VERSION
+          ls docs/release/$RELEASE_VERSION
+          
+          git add docs/release/$RELEASE_VERSION/openapi3.yaml -f
+          
+          git status
+          
+          git commit -m "chore: Add openapi3 resource release $RELEASE_VERSION ($COMMIT_ID)"
 
       - name: Link docs
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,53 +11,6 @@ on:
     types: [published]
 
 jobs:
-  test-swagger-url:
-    runs-on: ubuntu-latest
-    permissions: write-all
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Save scripts, config
-        uses: actions/upload-artifact@v4
-        with:
-          name: docs
-          path: |
-            .github/scripts/link_docs.py
-            .github/scripts/add_swagger_url.py
-
-      - name: Checkout gh-pages branch
-        uses: actions/checkout@v4
-        with:
-          ref: 'gh-pages'
-
-      - name: Set python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.10'
-
-      - name: Install python3 dependencies
-        run: pip3 install pyyaml
-
-      - name: Download scripts
-        uses: actions/download-artifact@v4
-        with:
-          name: docs
-          path: .
-
-      - name: ls -R
-        run: ls -R
-
-      - name: Cat
-        run: cat docs/swagger-ui/swagger-config.yaml
-
-      - name: Run
-        run: python3 add_swagger_url.py -u url -n hi3 -f docs/swagger-ui/swagger-config.yaml
-
-      - name: Cat
-        run: cat docs/swagger-ui/swagger-config.yaml
-
-
   build:
     runs-on: ubuntu-latest
     permissions: write-all
@@ -212,6 +165,7 @@ jobs:
           name: docs
           path: |
             .github/scripts/link_docs.py
+            .github/scripts/add_swagger_url.py
 
       - name: Checkout gh-pages branch
         uses: actions/checkout@v4
@@ -284,6 +238,21 @@ jobs:
           git status
 
           git commit -m "docs: Jacoco reports release $RELEASE_VERSION ($COMMIT_ID)"
+
+      - name: Install python3 dependencies for add openapi3 url to swagger config script
+        run: pip3 install pyyaml
+
+      - name: Add url to swagger config
+        run: |
+          cat docs/swagger-ui/swagger-config.yaml
+          python3 add_swagger_url.py -u https://can019.github.io/spring-base/release/$RELEASE_VERSION/openapi3.yaml -n $RELEASE_VERSION -f docs/swagger-ui/swagger-config.yaml
+          cat docs/swagger-ui/swagger-config.yaml
+          
+          echo "- [Swagger](https://can019.github.io/spring-base/swagger-ui/index.html?urls.primaryName=$RELEASE_VERSION)" >> docs/release/$RELEASE_VERSION/index.md
+          
+          git add docs/swagger-ui/swagger-config.yaml -f
+          git add docs/release/$RELEASE_VERSION/index.md -f
+          git commit -m "chore: Add $RELEASE_VERSION ($COMMIT_ID) openapi3.yaml"
 
       - name: Commit Openapi3 yaml
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,53 @@ on:
     types: [published]
 
 jobs:
+  test-swagger-url:
+    runs-on: ubuntu-latest
+    permissions: write-all
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Save scripts, config
+        uses: actions/upload-artifact@v4
+        with:
+          name: docs
+          path: |
+            .github/scripts/link_docs.py
+            .github/scripts/add_swagger_url.py
+
+      - name: Checkout gh-pages branch
+        uses: actions/checkout@v4
+        with:
+          ref: 'gh-pages'
+
+      - name: Set python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+
+      - name: Install python3 dependencies
+        run: pip3 install pyyaml
+
+      - name: Download scripts
+        uses: actions/download-artifact@v4
+        with:
+          name: docs
+          path: .
+
+      - name: ls -R
+        run: ls -R
+
+      - name: Cat
+        run: cat docs/swagger-ui/swagger-config.yaml
+
+      - name: Run
+        run: python3 add_swagger_url.py -u url -n hi3 -f docs/swagger-ui/swagger-config.yaml
+
+      - name: Cat
+        run: cat docs/swagger-ui/swagger-config.yaml
+
+
   build:
     runs-on: ubuntu-latest
     permissions: write-all

--- a/build.gradle
+++ b/build.gradle
@@ -52,9 +52,13 @@ dependencies {
 			replacedBy("org.springframework.boot:spring-boot-starter-log4j2")
 		}
 	}
-
 	// actuator
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
+
+	// rest assured
+	testImplementation 'io.rest-assured:rest-assured' // add rest-assured dependency
+	testImplementation 'org.springframework.restdocs:spring-restdocs-restassured'
+
 }
 
 configurations {
@@ -74,7 +78,6 @@ configurations {
 	unitTestAnnotationProcessor.extendsFrom testAnnotationProcessor
 	integrationTestCompileOnly.extendsFrom testCompileOnly
 	integrationTestAnnotationProcessor.extendsFrom testAnnotationProcessor
-
 }
 
 sourceSets {

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ plugins {
 }
 
 group = 'com.github.can019'
-version = '0.0.1-SNAPSHOT'
+version = '0.2.0-SNAPSHOT'
 
 java {
 	sourceCompatibility = '21'
@@ -187,7 +187,7 @@ openapi3 {
 	server = 'http://localhost:8080'
 	title = 'SPRING-BASE'
 	description = 'Spring base'
-	version = '0.1.0'
+	version = '0.2.0'
 	format = 'yaml'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -4,6 +4,8 @@ plugins {
 	id 'io.spring.dependency-management' version '1.1.4'
 	id 'jacoco'
 	id 'org.sonarqube' version '4.2.1.3168'
+	id "org.asciidoctor.jvm.convert" version "3.3.2"
+	id 'com.epages.restdocs-api-spec' version '0.19.2' // 1
 }
 
 group = 'com.github.can019'
@@ -59,6 +61,9 @@ dependencies {
 	testImplementation 'io.rest-assured:rest-assured' // add rest-assured dependency
 	testImplementation 'org.springframework.restdocs:spring-restdocs-restassured'
 
+	testImplementation 'com.epages:restdocs-api-spec-restassured:0.19.2' // 3
+	testImplementation 'com.epages:restdocs-api-spec-mockmvc:0.19.2'
+
 }
 
 configurations {
@@ -95,6 +100,11 @@ sourceSets {
 		runtimeClasspath += main.output + test.output
 	}
 }
+
+ext {
+	snippetsDir = file("build/generated-snippets")
+}
+
 tasks.withType(JacocoReport) {
 	reports {
 		html.required = true
@@ -166,6 +176,20 @@ sonar {
 	}
 }
 
+asciidoctor {
+	doFirst {
+		delete file("src/main/resources/static/docs")
+	}
+	sourceDir snippetsDir
+}
+
+openapi3 {
+	server = 'http://localhost:8080'
+	title = 'SPRING-BASE'
+	description = 'Spring base'
+	version = '0.1.0'
+	format = 'yaml'
+}
 
 check.dependsOn integrationTest
 check.dependsOn unitTest

--- a/src/integration/java/com/github/can019/domain/HelloControllerE2ETest.java
+++ b/src/integration/java/com/github/can019/domain/HelloControllerE2ETest.java
@@ -1,6 +1,6 @@
 package com.github.can019.domain;
 
-import io.restassured.RestAssured;
+import com.epages.restdocs.apispec.RestAssuredRestDocumentationWrapper;
 import io.restassured.builder.RequestSpecBuilder;
 import io.restassured.specification.RequestSpecification;
 import org.junit.jupiter.api.BeforeEach;
@@ -17,7 +17,7 @@ import static io.restassured.RestAssured.given;
 import static org.springframework.restdocs.restassured.RestAssuredRestDocumentation.document;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@ExtendWith({RestDocumentationExtension.class})
+@ExtendWith(RestDocumentationExtension.class)
 public class HelloControllerE2ETest {
 
     @LocalServerPort
@@ -26,10 +26,10 @@ public class HelloControllerE2ETest {
     private RequestSpecification spec;
 
     @BeforeEach
-    void setUp(RestDocumentationContextProvider restDocumentation) {
-        RestAssured.port = port;
+    void setUp(RestDocumentationContextProvider provider) {
+//        RestAssured.port = port;
         this.spec = new RequestSpecBuilder()
-                .addFilter(RestAssuredRestDocumentation.documentationConfiguration(restDocumentation))
+                .addFilter(RestAssuredRestDocumentation.documentationConfiguration(provider))
                 .setPort(port)
                 .build();
     }
@@ -38,7 +38,7 @@ public class HelloControllerE2ETest {
     @DisplayName("Hello get mapping")
     void hello() throws Exception {
         given(this.spec)
-                .filter(document("hello"))
+                .filter(RestAssuredRestDocumentationWrapper.document("hello","[Get] hello"))
                 .when()
                 .get("/api/v0/hello")
                 .then()

--- a/src/integration/java/com/github/can019/domain/HelloControllerE2ETest.java
+++ b/src/integration/java/com/github/can019/domain/HelloControllerE2ETest.java
@@ -1,0 +1,48 @@
+package com.github.can019.domain;
+
+import io.restassured.RestAssured;
+import io.restassured.builder.RequestSpecBuilder;
+import io.restassured.specification.RequestSpecification;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.restdocs.RestDocumentationContextProvider;
+import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.restdocs.restassured.RestAssuredRestDocumentation;
+
+import static io.restassured.RestAssured.given;
+import static org.springframework.restdocs.restassured.RestAssuredRestDocumentation.document;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ExtendWith({RestDocumentationExtension.class})
+public class HelloControllerE2ETest {
+
+    @LocalServerPort
+    public int port;
+
+    private RequestSpecification spec;
+
+    @BeforeEach
+    void setUp(RestDocumentationContextProvider restDocumentation) {
+        RestAssured.port = port;
+        this.spec = new RequestSpecBuilder()
+                .addFilter(RestAssuredRestDocumentation.documentationConfiguration(restDocumentation))
+                .setPort(port)
+                .build();
+    }
+
+    @Test
+    @DisplayName("Hello get mapping")
+    void hello() throws Exception {
+        given(this.spec)
+                .filter(document("hello"))
+                .when()
+                .get("/api/v0/hello")
+                .then()
+                .assertThat()
+                .statusCode(200);
+    }
+}

--- a/src/main/java/com/github/can019/domain/hello/HelloController.java
+++ b/src/main/java/com/github/can019/domain/hello/HelloController.java
@@ -1,0 +1,13 @@
+package com.github.can019.domain.hello;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class HelloController {
+
+    @GetMapping("/api/v0/hello")
+    public String hello() {
+        return "hello";
+    }
+}


### PR DESCRIPTION
Resolve #29
## ✨ New features
### Spring rest docs
- Spring rest docs는 테스트가 수행된 경우만 api 문서로 만들어줌
  - api 문서의 신뢰도
- 비지니스 코드에 침투하지 않음
  - Swagger의 경우 annotation이 비지니스 코드에 침투

### OpenApi3(swagger)와 Spring rest docs의 연동
#### Spring rest docs의 단점
  - 좋지 않은 명세서 디자인
  - Postman과 같은 test 불가
  - .adoc 형식의 문서
  - 파편화 된 api 명세서
    - 명세서는 각 api마다 6개씩 생성됨
    - 이를 모으려면 index.adoc을 수기로 작성하거나 따로 자동화해야함
#### Asciidoctor vs swagger
- Asciidoctor의 경우 test가 불가능하며 파편화 된 api 명세서를 모아줘야 함
- Swagger의 경우 Spring rest docs의 adoc을 openapi3.yml로 변환시킨 후 배포하면 됨

### Github pages에 배포
- Github pages에 배포된 swagger는 test가 불가능
  - 추 후 CQRS 설정 또는 로컬에서 도커로 test가 가능한 swagger 추가 예정
- Static한 api 명세서로 생각하면 됨

## 🧱 Dependency
- `testImplementation` `io.rest-assured:rest-assured`
  - Rest assured
- `testImplementation` `org.springframework.restdocs:spring-restdocs-restassured`
- `testImplementation` `com.epages:restdocs-api-spec-*`
  - Spring rest docs를 openapi3.yml로 변환을 위한 라이브러리