### PR TITLE
Test Container (MySQL)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -64,6 +64,12 @@ dependencies {
 	testImplementation 'com.epages:restdocs-api-spec-restassured:0.19.2' // 3
 	testImplementation 'com.epages:restdocs-api-spec-mockmvc:0.19.2'
 
+	// test container
+	testImplementation 'org.testcontainers:junit-jupiter'
+	testImplementation "org.testcontainers:mysql:1.19.8"
+	runtimeOnly 'com.mysql:mysql-connector-j'
+	testImplementation "org.testcontainers:mysql"
+
 }
 
 configurations {

--- a/build.gradle
+++ b/build.gradle
@@ -66,9 +66,8 @@ dependencies {
 
 	// test container
 	testImplementation 'org.testcontainers:junit-jupiter'
-	testImplementation "org.testcontainers:mysql:1.19.8"
 	runtimeOnly 'com.mysql:mysql-connector-j'
-	testImplementation "org.testcontainers:mysql"
+	testImplementation 'org.testcontainers:mysql'
 
 }
 

--- a/src/integration/java/com/github/can019/test/dependency/testcontainer/TestContainerMysqlTest.java
+++ b/src/integration/java/com/github/can019/test/dependency/testcontainer/TestContainerMysqlTest.java
@@ -1,0 +1,42 @@
+package com.github.can019.test.dependency.testcontainer;
+
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import javax.sql.DataSource;
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.SQLException;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@DataJpaTest
+@ActiveProfiles("test")
+@Testcontainers
+public class TestContainerMysqlTest {
+
+    @PersistenceContext
+    private EntityManager em;
+
+    @Autowired
+    private DataSource dataSource;
+
+    @Test
+    @DisplayName("TestContainer mysql과 연동되어야 한다")
+    void checkUsingMysqlContainer() throws SQLException {
+        try (Connection connection = dataSource.getConnection()) {
+            DatabaseMetaData metaData = connection.getMetaData();
+            String databaseProductName = metaData.getDatabaseProductName();
+            assertThat(databaseProductName).isEqualTo("MySQL");
+        }
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -52,6 +52,9 @@ spring:
   config:
     activate:
       on-profile: silence
+  datasource:
+    url: jdbc:tc:mysql:8.0.32:///test
+    driver-class-name: org.testcontainers.jdbc.ContainerDatabaseDriver
   main:
     banner-mode: OFF
   jpa:
@@ -65,6 +68,22 @@ spring:
 
 log4j:
   configurationFile: classpath:log4j2-silence.yml
+---
+spring:
+  config:
+    activate:
+      on-profile: test
+  datasource:
+    url: jdbc:tc:mysql:8.0.32:///test
+    driver-class-name: org.testcontainers.jdbc.ContainerDatabaseDriver
+  jpa:
+    hibernate:
+      ddl-auto: create
+    properties:
+      hibernate:
+        show_sql: false
+        use_sql_comments: false
+        highlight_sql: false
 ---
 spring:
   config:


### PR DESCRIPTION
## ✨ New features
### TestContainer
- Test시 H2 Database가 아닌 실제 MySQL과 연동 테스트가 필요하는 경우를 위함
  - Database dialect등
- 각 class는 다른 test container를 사용, 격리된 환경에서 테스트 진행 가능
## 🧱 Dependency
- `org.testcontainers:junit-jupiter`
  - TestContainer
- `org.testcontainers:mysql`
  - TestContainer의 MySQL database
- `com.mysql:mysql-connector-j`
  - TestContainer의 MysSQL 연결은 jdbc MySQL driver를 이용