### PR TITLE
Test 수행 시 수행 시간을 측정하는 TestExecutionListener

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,5 @@
 # Spring-base ![Coverage](https://sonarcloud.io/api/project_badges/measure?project=can019_spring-base&metric=coverage) ![Reliability Rating](https://sonarcloud.io/api/project_badges/measure?project=can019_spring-base&metric=reliability_rating) ![Security Rating](https://sonarcloud.io/api/project_badges/measure?project=can019_spring-base&metric=security_rating) ![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=can019_spring-base&metric=sqale_rating) ![Vulnerabilities](https://sonarcloud.io/api/project_badges/measure?project=can019_spring-base&metric=vulnerabilities) ![Code Smells](https://sonarcloud.io/api/project_badges/measure?project=can019_spring-base&metric=code_smells)
 
-
-
-
-
 프로젝트 설명...
 
 
@@ -30,6 +26,10 @@
 
 - CI에서 Sonar cloud를 이용해 정적 분석을 진행합니다.
   - 해당 PR에서 추가된 source code에 대해 평가합니다.
+
+
+### Test 수행 시간 측정 및 export report
+- [총 수행 시간, method별 수행 시간 측정 후 csv로 export 하는 TestExecutionListener](https://github.com/can019/spring-base/pull/58)
 
 
 ## 프로젝트 환경

--- a/src/integration/java/com/github/can019/test/util/listener/performance/BasicTestTimeExecutionListener.java
+++ b/src/integration/java/com/github/can019/test/util/listener/performance/BasicTestTimeExecutionListener.java
@@ -1,0 +1,39 @@
+package com.github.can019.test.util.listener.performance;
+
+import com.github.can019.test.util.report.StopWatchReporter;
+import org.springframework.test.context.TestContext;
+import org.springframework.test.context.support.AbstractTestExecutionListener;
+import org.springframework.util.StopWatch;
+
+import static com.github.can019.test.util.report.StopWatchReporter.exportReport;
+
+/**
+ * Non thread safe
+ * 자동으로 각 test method의 수행 시간을 측정, csv로 export
+ * `@Execution(value = ExecutionMode.SAME_THREAD)`에서만 사용 가능
+ */
+public class BasicTestTimeExecutionListener extends AbstractTestExecutionListener {
+    private StopWatch stopWatch;
+
+    @Override
+    public void beforeTestClass(TestContext testContext) throws Exception {
+        super.beforeTestClass(testContext);
+        stopWatch = new StopWatch(testContext.getTestClass().getSimpleName());
+    }
+
+    @Override
+    public void beforeTestMethod(TestContext testContext) throws Exception {
+        super.beforeTestMethod(testContext);
+        stopWatch.start(testContext.getTestMethod().getName());
+    }
+
+    @Override
+    public void afterTestMethod(TestContext testContext) throws Exception {
+        if (stopWatch.isRunning()) {
+            stopWatch.stop();
+        }
+        super.afterTestMethod(testContext);
+
+        exportReport(stopWatch, "total", testContext.getTestClass(),  StopWatchReporter.ReportType.CSV);
+    }
+}

--- a/src/integration/java/com/github/can019/test/util/listener/performance/ParallelTestTimeExecutionListener.java
+++ b/src/integration/java/com/github/can019/test/util/listener/performance/ParallelTestTimeExecutionListener.java
@@ -1,0 +1,41 @@
+package com.github.can019.test.util.listener.performance;
+
+import com.github.can019.test.util.report.StopWatchReporter;
+import org.springframework.test.context.TestContext;
+import org.springframework.test.context.support.AbstractTestExecutionListener;
+import org.springframework.util.StopWatch;
+
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
+import static com.github.can019.test.util.report.StopWatchReporter.*;
+
+public class ParallelTestTimeExecutionListener extends AbstractTestExecutionListener {
+    private static final ThreadLocal<StopWatch> threadLocalStopWatch =
+            ThreadLocal.withInitial(StopWatch::new);
+
+    private final SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd-HH-mm-ss");
+    private final Date startedTime = new Date();
+
+    public static StopWatch getStopWatch(){
+        return threadLocalStopWatch.get();
+    }
+
+    @Override
+    public void beforeTestMethod(TestContext testContext) throws Exception {
+        super.beforeTestMethod(testContext);
+        Thread.currentThread().setName(testContext.getTestMethod().getName());
+    }
+
+    @Override
+    public void afterTestMethod(TestContext testContext) throws Exception {
+        super.afterTestMethod(testContext);
+        StopWatch stopWatch = this.getStopWatch();
+        threadLocalStopWatch.remove();
+
+        exportReport(stopWatch,
+                String.join("/","parallel",testContext.getTestMethod().getName()),
+                testContext.getTestClass(),
+                StopWatchReporter.ReportType.CSV);
+    }
+}

--- a/src/integration/java/com/github/can019/test/util/listener/performance/TotalTestTimeExecutionListener.java
+++ b/src/integration/java/com/github/can019/test/util/listener/performance/TotalTestTimeExecutionListener.java
@@ -1,9 +1,12 @@
 package com.github.can019.test.util.listener.performance;
 
+import com.github.can019.test.util.report.StopWatchReporter;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.test.context.TestContext;
 import org.springframework.test.context.support.AbstractTestExecutionListener;
 import org.springframework.util.StopWatch;
+
+import static com.github.can019.test.util.report.StopWatchReporter.exportReport;
 
 @Slf4j
 public class TotalTestTimeExecutionListener extends AbstractTestExecutionListener {
@@ -24,5 +27,7 @@ public class TotalTestTimeExecutionListener extends AbstractTestExecutionListene
 
         log.info("The test in '{}' has been completed",testContext.getTestClass().getSimpleName());
         log.info(totalTaskStopWatch.prettyPrint());
+
+        exportReport(totalTaskStopWatch, "total", testContext.getTestClass(),  StopWatchReporter.ReportType.CSV);
     }
 }

--- a/src/integration/java/com/github/can019/test/util/listener/performance/TotalTestTimeExecutionListener.java
+++ b/src/integration/java/com/github/can019/test/util/listener/performance/TotalTestTimeExecutionListener.java
@@ -1,0 +1,28 @@
+package com.github.can019.test.util.listener.performance;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.test.context.TestContext;
+import org.springframework.test.context.support.AbstractTestExecutionListener;
+import org.springframework.util.StopWatch;
+
+@Slf4j
+public class TotalTestTimeExecutionListener extends AbstractTestExecutionListener {
+    private StopWatch totalTaskStopWatch;
+
+    @Override
+    public void beforeTestClass(TestContext testContext) throws Exception {
+        log.info("Running test '{}'...",testContext.getTestClass().getSimpleName());
+        totalTaskStopWatch = new StopWatch(testContext.getTestClass().getSimpleName()+ " Total");
+        totalTaskStopWatch.start("Total");
+        super.beforeTestClass(testContext);
+    }
+
+    @Override
+    public void afterTestClass(TestContext testContext) throws Exception {
+        super.afterTestClass(testContext);
+        totalTaskStopWatch.stop();
+
+        log.info("The test in '{}' has been completed",testContext.getTestClass().getSimpleName());
+        log.info(totalTaskStopWatch.prettyPrint());
+    }
+}

--- a/src/integration/java/com/github/can019/test/util/report/ReportPath.java
+++ b/src/integration/java/com/github/can019/test/util/report/ReportPath.java
@@ -1,0 +1,15 @@
+package com.github.can019.test.util.report;
+
+public enum ReportPath {
+    ROOT_PATH("build/test-reports");
+
+    private String path;
+
+    ReportPath(String path) {
+        this.path = path;
+    }
+
+    public String getPath() {
+        return this.path;
+    }
+}

--- a/src/integration/java/com/github/can019/test/util/report/StopWatchReporter.java
+++ b/src/integration/java/com/github/can019/test/util/report/StopWatchReporter.java
@@ -1,0 +1,83 @@
+package com.github.can019.test.util.report;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.util.StopWatch;
+
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.lang.reflect.Method;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.List;
+
+@Slf4j
+public class StopWatchReporter {
+    private final static SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd-HH-mm-ss");
+
+    public enum ReportType{
+        CSV("csv");
+
+        private String extension;
+
+        ReportType(String extension){
+            this.extension = extension;
+        }
+
+        public String getExtension() {
+            return extension;
+        }
+    }
+
+    public static void exportReport(StopWatch stopWatch, String fileName, Class clazz, ReportType reportType) {
+        String exportPath = getExportPath(fileName, clazz, reportType);
+        Path directoryPath = Paths.get(exportPath).getParent();
+
+        createDirectory(directoryPath);
+
+        switch (reportType){
+            case CSV -> writeCsv(stopWatch, exportPath);
+            default -> throw new RuntimeException("Unsupported ReportType");
+        }
+    }
+
+    public static String getExportPath(String fileName, Class clazz, ReportType reportType) {
+        return String.join("/",
+                ReportPath.ROOT_PATH.getPath(),
+                clazz.getPackageName(),
+                clazz.getSimpleName(),
+                dateFormat.format(new Date()),
+                fileName + "."+reportType.getExtension());
+    }
+
+    private static void writeCsv(StopWatch stopWatch, String filePath) {
+        List<StopWatch.TaskInfo> taskInfoList = List.of(stopWatch.getTaskInfo());
+
+        try (PrintWriter writer = new PrintWriter(new FileWriter(filePath))) {
+            writer.println("Task Name,Total Time (nano second)");
+
+            for (StopWatch.TaskInfo taskInfo : taskInfoList) {
+                String taskName = taskInfo.getTaskName();
+                long totalTimeMillis = taskInfo.getTimeNanos();
+
+                writer.println(taskName +"," + totalTimeMillis);
+            }
+            System.out.println("CSV report created");
+        } catch (IOException e) {
+            System.err.println("Error occurred while creating CSV report " + e.getMessage());
+        }
+    }
+
+    private static void createDirectory(Path path) {
+        try {
+            if(!Files.exists(path)){
+                Files.createDirectories(path);
+            }
+        } catch (IOException e) {
+            log.error("Error creating directory: {}", e.getMessage());
+        }
+    }
+}


### PR DESCRIPTION
<!-- 필요한 항목만 작성 -->
## ✨ New features
###  Test 수행 시 시간 측정 후 csv export하는 TestExecutionListener
- TotalTestTimeExecutionListener : 총 수행 시간 측정
- BasicTestTimeExecutionListener: 각 method마다 자동으로 측정 (Non-thread-safe)
- ParalleTestTimeExecutionListener: 각 method마다 자동으로 측정 (Thread-safe)
   - parallel 가능
   - `@RepeatedTest` + parallel은 불가
     - 위 경우 복잡하기 때문에 각 Test class에서 측정, report하는 것을 추천
     - [Example](https://github.com/can019/mysql-primary-key/blob/main/src/integration/java/com/github/can019/performance/PrimaryKeyPerformanceTestMultiThreadV2.java)
 #### 적용 방법
  ```java
@TestExecutionListeners(value = {TotalTestTimeExecutionListener},
         mergeMode = TestExecutionListeners.MergeMode.MERGE_WITH_DEFAULTS)
```
## 📝 Docs
### README.md Project 특징에 TestExecutionListener 추가