### PR TITLE
Build 실패 시 test, PR comment 등 이 후 step이 진행되지 않는 버그 수정

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,7 @@ jobs:
 
       - name: Build
         run: gradle build --configuration-cache --info
+        continue-on-error: true
 
       - name: Generate unit jacoco report
         run: gradle unitTestJacocoReport --configuration-cache
@@ -106,7 +107,7 @@ jobs:
           check_name: 'Integration test'
 
   set-github-pages-resource:
-    if: github.event.action == 'published'
+    if: always() && github.event.action == 'published'
     runs-on: ubuntu-latest
     permissions: write-all
     needs: [gradle-task]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,14 @@ jobs:
           cache-encryption-key: ${{ secrets.GradleEncryptionKey }}
 
       - name: Build
-        run: gradle build --configuration-cache --info
+        run: gradle build -x check --configuration-cache --info
+
+      - name: IntegrationTest
+        run: gradle integrationTest --configuration-cache --info
+        continue-on-error: true
+
+      - name: UnitTest
+        run: gradle unitTest --configuration-cache --info
         continue-on-error: true
 
       - name: Generate unit jacoco report


### PR DESCRIPTION
## 🐛 Fix
### Ci build 실패 시 pr comment가 되지 않는 버그 수정
- Continue-on-error: true 설정
## ✏️ Changed
### Ci gradle-task job에서 Build, test 분리
- 실패 시 test의 문제인지 build의 문제인지 명확하게 하기 위해 분