### PR TITLE
Interceptor, filter test 추가

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: reports
-          path: build
+          path: .
 
       - name: Check all dir
         run: ls -R

--- a/api/src/test/java/com/github/can019/base/api/global/aop/logger/LayeredArchitectureLogAspectIntegrationTest.java
+++ b/api/src/test/java/com/github/can019/base/api/global/aop/logger/LayeredArchitectureLogAspectIntegrationTest.java
@@ -1,0 +1,47 @@
+package com.github.can019.base.api.global.aop.logger;
+
+import com.github.can019.base.api.global.aop.logger.resource.LogAspectTestController;
+import com.github.can019.base.api.global.aop.logger.resource.LogAspectTestRepository;
+import com.github.can019.base.api.global.aop.logger.resource.LogAspectTestService;
+import org.aspectj.lang.JoinPoint;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import org.mockito.Mockito;
+import org.springframework.aop.aspectj.annotation.AnnotationAwareAspectJAutoProxyCreator;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Profile;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@Import({LogAspectTestController.class, LogAspectTestService.class, LogAspectTestRepository.class, AnnotationAwareAspectJAutoProxyCreator.class})
+@Profile("test")
+public class LayeredArchitectureLogAspectIntegrationTest {
+    @Autowired
+    private LogAspectTestController testController;
+
+    @Autowired
+    private ApplicationContext ac;
+
+    @SpyBean
+    private LayeredArchitectureLogAspect.BaseLogAspect baseLogAspect;
+
+
+    void findBeanByType(String beanName, Class clazz) {
+        boolean isBeanPresent = ac.containsBeanDefinition(beanName);
+        boolean isBeanPresentByClass = ac.getBeansOfType(clazz).size() > 0;
+
+        assertThat(isBeanPresent || isBeanPresentByClass).isTrue();
+    }
+
+    @Test
+    @DisplayName("LayeredArchitectureLogAspect.BaseLogAspect.class가 bean으로 등록되어있어야 한다")
+    void isLayeredArchitectureLogAspectIsInApplicationContext() {
+        findBeanByType("layeredArchitectureLogAspect.BaseLogAspect", LayeredArchitectureLogAspect.BaseLogAspect.class);
+    }
+}

--- a/api/src/test/java/com/github/can019/base/api/global/aop/logger/LayeredArchitectureLogAspectUnitTest.java
+++ b/api/src/test/java/com/github/can019/base/api/global/aop/logger/LayeredArchitectureLogAspectUnitTest.java
@@ -1,0 +1,68 @@
+package com.github.can019.base.api.global.aop.logger;
+
+import net.datafaker.Faker;
+import org.aspectj.lang.JoinPoint;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.junit.jupiter.api.Test;
+import org.aspectj.lang.Signature;
+
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class LayeredArchitectureLogAspectUnitTest {
+    @Mock
+    private JoinPoint joinPoint;
+
+    @Mock
+    private Signature signature;
+
+    @InjectMocks
+    private LayeredArchitectureLogAspect.BaseLogAspect baseLogAspect;
+
+    private Faker faker = new Faker();
+
+    @Test
+    public void testDefaultInputLog() {
+        when(joinPoint.getSignature()).thenReturn(signature);
+        when(signature.toShortString()).thenReturn("MockedMethod()");
+        when(joinPoint.getArgs()).thenReturn(new Object[] {"arg1", "arg2"});
+        when(joinPoint.getTarget()).thenReturn(new Object());
+
+        LayeredArchitectureLogAspect.defaultTraceInputLog(joinPoint);
+
+        verify(joinPoint).getSignature();
+        verify(joinPoint).getArgs();
+        verify(joinPoint).getTarget();
+    }
+
+    @Test
+    public void testDefaultOutputLog() {
+        when(joinPoint.getSignature()).thenReturn(signature);
+        when(signature.toShortString()).thenReturn("MockedMethod()");
+        when(joinPoint.getTarget()).thenReturn(new Object());
+        Object returnValue = "MockedReturn";
+
+        LayeredArchitectureLogAspect.defaultTraceOutputLog(joinPoint, returnValue);
+
+        verify(joinPoint).getSignature();
+        verify(joinPoint).getTarget();
+    }
+
+    @Test
+    public void testErrorLog() {
+        when(joinPoint.getSignature()).thenReturn(signature);
+        when(signature.toShortString()).thenReturn("MockedMethod()");
+        String randomExceptionMessage = faker.lorem().sentence();
+
+        RuntimeException exception = spy(new RuntimeException(randomExceptionMessage));
+
+        LayeredArchitectureLogAspect.errorLog(joinPoint, exception);
+
+        verify(joinPoint).getSignature();
+        verify(exception).getMessage();
+        verify(exception).getStackTrace();
+    }
+}

--- a/api/src/test/java/com/github/can019/base/api/global/aop/logger/resource/LogAspectTestController.java
+++ b/api/src/test/java/com/github/can019/base/api/global/aop/logger/resource/LogAspectTestController.java
@@ -1,0 +1,16 @@
+package com.github.can019.base.api.global.aop.logger.resource;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class LogAspectTestController {
+    private final LogAspectTestService service;
+
+    @GetMapping("test/log/void")
+    public void executeVoidReturnMethodInController(Object arg1, Object arg2) {
+        service.executeVoidReturnMethodInService(arg1, arg2);
+    }
+}

--- a/api/src/test/java/com/github/can019/base/api/global/aop/logger/resource/LogAspectTestRepository.java
+++ b/api/src/test/java/com/github/can019/base/api/global/aop/logger/resource/LogAspectTestRepository.java
@@ -1,0 +1,11 @@
+package com.github.can019.base.api.global.aop.logger.resource;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class LogAspectTestRepository {
+
+    void executeVoidReturnMethodInRepository(Object arg1, Object arg2) {
+
+    }
+}

--- a/api/src/test/java/com/github/can019/base/api/global/aop/logger/resource/LogAspectTestService.java
+++ b/api/src/test/java/com/github/can019/base/api/global/aop/logger/resource/LogAspectTestService.java
@@ -1,0 +1,14 @@
+package com.github.can019.base.api.global.aop.logger.resource;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class LogAspectTestService {
+    private final LogAspectTestRepository repository;
+
+    void executeVoidReturnMethodInService(Object arg1, Object arg2) {
+        repository.executeVoidReturnMethodInRepository(arg1, arg2);
+    }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -61,6 +61,10 @@ subprojects {
 				replacedBy("org.springframework.boot:spring-boot-starter-log4j2")
 			}
 		}
+		testImplementation 'org.apache.logging.log4j:log4j-core'
+		testImplementation 'org.apache.logging.log4j:log4j-core-test'
+
+
 		// actuator
 		implementation 'org.springframework.boot:spring-boot-starter-actuator:3.2.5'
 

--- a/build.gradle
+++ b/build.gradle
@@ -75,6 +75,8 @@ subprojects {
 		testImplementation 'org.testcontainers:junit-jupiter:1.19.7'
 		runtimeOnly 'com.mysql:mysql-connector-j:8.3.0'
 		testImplementation 'org.testcontainers:mysql:1.19.7'
+
+		implementation 'net.datafaker:datafaker:2.3.1'
 	}
 
 	configurations {

--- a/core/src/test/java/com/github/can019/base/core/interceptor/LoggingInterceptorIntegrationTest.java
+++ b/core/src/test/java/com/github/can019/base/core/interceptor/LoggingInterceptorIntegrationTest.java
@@ -1,0 +1,104 @@
+package com.github.can019.base.core.interceptor;
+
+import com.github.can019.base.core.interceptor.resource.LoggingInterceptorTestController;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.core.config.Configurator;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@WebMvcTest
+@Import({LoggingInterceptorTestController.class})
+public class LoggingInterceptorIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    private final ByteArrayOutputStream outContent = new ByteArrayOutputStream();
+    private final PrintStream originalOut = System.out;
+
+    @BeforeEach
+    void beforeEach() {
+        setUptStream();
+    }
+
+    @AfterEach
+    void afterEach() {
+        restoreStream();
+    }
+
+    @Test
+    @DisplayName("Log level이 trace level일 때 api 요청을 했을 때 loggingInterceptor는 로그를 세 번 찍어야 한다.")
+    public void logTestWhenTraceLevel() throws Exception {
+        final String getRequestUri = "/test/logging-interceptor/get";
+        setLogLevel(Level.TRACE);
+        mockMvc.perform(get(getRequestUri));
+
+        List<String> outputList = Arrays.asList(outContent.toString().split("\n"));
+
+        List<String> filteredLogs = outputList.stream()
+                .filter(log -> log.contains("LoggingInterceptor"))
+                .collect(Collectors.toList());
+
+        assertThat(filteredLogs.size()).isEqualTo(3);
+    }
+
+    @Test
+    @DisplayName("Log level이 info level일 때 api 요청을 했을 때 loggingInterceptor는 로그를 한 번 찍어야 한다.")
+    public void logTestWhenInfoLevel() throws Exception {
+        final String getRequestUri = "/test/logging-interceptor/get";
+        setLogLevel(Level.INFO);
+        mockMvc.perform(get(getRequestUri));
+
+        List<String> outputList = Arrays.asList(outContent.toString().split("\n"));
+
+        List<String> filteredLogs = outputList.stream()
+                .filter(log -> log.contains("LoggingInterceptor"))
+                .collect(Collectors.toList());
+
+        assertThat(filteredLogs.size()).isEqualTo(1);
+    }
+
+    public void setLogLevel(Level logLevel) {
+        Configurator.setLevel("com.github.can019", logLevel);
+    }
+
+    public void setRootLogLevel(Level logLevel){
+        Configurator.setRootLevel(logLevel);
+    }
+
+    public void setUptStream() {
+        System.setOut(new PrintStream(outContent));
+    }
+
+    public void restoreStream() {
+        System.setOut(originalOut);
+    }
+
+    @Configuration
+    static class TestConfig implements WebMvcConfigurer {
+
+        @Override
+        public void addInterceptors(InterceptorRegistry registry) {
+            registry.addInterceptor(new LoggingInterceptor())
+                    .addPathPatterns("/**");
+        }
+    }
+}

--- a/core/src/test/java/com/github/can019/base/core/interceptor/resource/LoggingInterceptorTestController.java
+++ b/core/src/test/java/com/github/can019/base/core/interceptor/resource/LoggingInterceptorTestController.java
@@ -1,0 +1,15 @@
+package com.github.can019.base.core.interceptor.resource;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class LoggingInterceptorTestController {
+
+    @GetMapping("test/logging-interceptor/get")
+    public ResponseEntity getMappingMethod() {
+        return new ResponseEntity(null, HttpStatus.OK);
+    }
+}


### PR DESCRIPTION
<!-- 필요한 항목만 작성 -->
## ✨ New features
### AOP logger test
- Log message 생성 method만 검즘
- Log message 형태 검증은 진행하지 않음
### LoggerInterceptor
- Log message 형태 검증은 진행하지 않음
- Log level에 따라 LoggerInterceptor class에서 console standard output가 몇번 일어났는지 검증
## 🧱 Dependency
### `testImplementation 'org.apache.logging.log4j:log4j-core`
- Test에서 log4j2 core 모듈 사용
### `testImplementation 'org.apache.logging.log4j:log4j-core-test`
- Test에서 log4j2 test 사용